### PR TITLE
PAY-211 Update android to load in SDKConfig to determine google pay environment

### DIFF
--- a/android/app/src/main/java/com/evervault/samplepayapp/MainActivity.kt
+++ b/android/app/src/main/java/com/evervault/samplepayapp/MainActivity.kt
@@ -27,9 +27,8 @@ import com.evervault.googlepay.Transaction
 class MainActivity : AppCompatActivity() {
 
     private val model: EvervaultPayViewModel by viewModels {
-        // Use staging for the test app.
-        EvervaultCustomConfig.apiBaseUrl = "https://api.evervault.io"
-
+        // Optional: Override the API Base URL when needed
+        // here by setting `EvervaultCustomConfig.apiBaseUrl`
         EvervaultPayViewModelFactory(
             application,
             Config(

--- a/android/app/src/main/java/com/evervault/samplepayapp/MainActivity.kt
+++ b/android/app/src/main/java/com/evervault/samplepayapp/MainActivity.kt
@@ -16,6 +16,7 @@ import com.evervault.googlepay.CardResponse
 import com.evervault.googlepay.EvervaultButtonTheme
 import com.evervault.googlepay.EvervaultButtonType
 import com.evervault.googlepay.EvervaultConstants
+import com.evervault.googlepay.EvervaultCustomConfig
 import com.evervault.googlepay.EvervaultPayViewModel
 import com.evervault.googlepay.EvervaultPayViewModelFactory
 import com.evervault.googlepay.NetworkTokenResponse
@@ -26,10 +27,12 @@ import com.evervault.googlepay.Transaction
 class MainActivity : AppCompatActivity() {
 
     private val model: EvervaultPayViewModel by viewModels {
+        // Use staging for the test app.
+        EvervaultCustomConfig.apiBaseUrl = "https://api.evervault.io"
+
         EvervaultPayViewModelFactory(
             application,
             Config(
-                environment = EvervaultConstants.ENVIRONMENT_TEST,
                 appId = BuildConfig.EVERVAULT_APP_ID,
                 merchantId = BuildConfig.EVERVAULT_MERCHANT_ID,
                 supportedNetworks = listOf(

--- a/android/googlepay/build.gradle.kts
+++ b/android/googlepay/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.evervault.payments" // Maven group ID
-version = "android-v0.0.3" // Bump per release
+version = "android-v0.0.24" // Bump per release
 
 android {
     namespace = "com.evervault.payments"

--- a/android/googlepay/src/main/java/com/evervault/googlepay/Config.kt
+++ b/android/googlepay/src/main/java/com/evervault/googlepay/Config.kt
@@ -3,7 +3,6 @@ package com.evervault.googlepay
 data class Config(
     val appId: String,
     val merchantId: String,
-    val environment: Int = EvervaultConstants.ENVIRONMENT_TEST,
     val supportedNetworks: List<CardNetwork>  = Constants.SUPPORTED_NETWORKS,
     val supportedMethods: List<CardAuthMethod> = Constants.SUPPORTED_METHODS,
 )

--- a/android/googlepay/src/main/java/com/evervault/googlepay/Constants.kt
+++ b/android/googlepay/src/main/java/com/evervault/googlepay/Constants.kt
@@ -2,7 +2,7 @@ package com.evervault.googlepay
 
 internal object Constants {
     const val API_BASE_URL_PRODUCTION = "https://api.evervault.com"
-    const val API_BASE_URL_TEST = "https://api.evervault.io"
+    const val API_BASE_URL_STAGING = "https://api.evervault.io"
     const val GATEWAY_TOKENIZATION_NAME = "evervault"
     val SUPPORTED_NETWORKS = CardNetwork.entries
     val SUPPORTED_METHODS = listOf(CardAuthMethod.PAN_ONLY, CardAuthMethod.CRYPTOGRAM_3DS)

--- a/android/googlepay/src/main/java/com/evervault/googlepay/EvervaultCustomConfig.kt
+++ b/android/googlepay/src/main/java/com/evervault/googlepay/EvervaultCustomConfig.kt
@@ -1,0 +1,10 @@
+package com.evervault.googlepay
+
+// This is a singleton for the app to override behaviour if desired.
+object EvervaultCustomConfig {
+    // Always set this to production
+    // To override this in a test app,
+    // assign a new value to "EvervaultCustomConfig.apiBaseUrl"
+    // before calling the `EvervaultPayViewModel`
+    var apiBaseUrl: String = Constants.API_BASE_URL_PRODUCTION
+}

--- a/android/googlepay/src/main/java/com/evervault/googlepay/SDKConfig.kt
+++ b/android/googlepay/src/main/java/com/evervault/googlepay/SDKConfig.kt
@@ -1,0 +1,3 @@
+package com.evervault.googlepay
+
+data class SDKConfig(val is_sandbox: Boolean)


### PR DESCRIPTION
Changes:
* Defaults to use the production CAPI URL in the SDK
* Allow the caller to override to another CAPI URL for (internal) testing
* Fetch the SDK Config (same as Evervault-JS) to determine if the native Google Pay Client should go into test mode or production mode.