### PR TITLE
chore(android): downgrade minSdkVersion from 26 to 24

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,10 @@ on:
       - 'android/**'
       - '.github/**'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,29 @@ on:
       - '.github/**'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    - name: Grant execute permission for gradlew
+      working-directory: android
+      run: chmod +x gradlew
+    - name: Run lint with Gradle
+      working-directory: android
+      run: ./gradlew :googlepay:lint
+    - name: Upload lint report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: lint-report
+        path: android/googlepay/build/reports/lint-results-*.html
+      
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,9 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         applicationId = "com.evervault.samplepayapp"
-        minSdk = 26
+        minSdk = 24
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/android/googlepay/build.gradle.kts
+++ b/android/googlepay/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 24
         // targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -48,7 +48,7 @@ android {
     }
     defaultConfig {
         aarMetadata {
-            minCompileSdk = 26
+            minCompileSdk = 24
         }
         // Temporary until upgrade to 34
         configurations.all {


### PR DESCRIPTION
## Summary

- Lowers \`minSdk\` from 26 to 24 in both the \`googlepay\` library and the \`app\` sample module
- Lowers \`minCompileSdk\` in the library's \`aarMetadata\` from 26 to 24 to match
- Adds a \`lint\` job to the Android CI workflow that runs \`./gradlew :googlepay:lint\` and uploads the HTML report as an artifact

## Breaking changes

**None.** The codebase contains no API 26-specific calls — no \`NotificationChannel\`, \`AutofillManager\`, \`@RequiresApi(26)\`, or any other Android 8.0 API. All dependencies (OkHttp 4.x, Jetpack Compose BOM 2023.03.00, play-services-wallet, Gson, all AndroidX libraries) already support API 21+.

Google Pay availability on API 24/25 devices is determined at runtime by \`isReadyToPay()\`, which already handles the case where Google Pay is unavailable — this change does not affect that behavior.

## Impact

Devices running Android 7.0 and 7.1 (API 24/25) can now install and use the library. Lint now runs in CI to catch issues on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)