### PR TITLE
Bump version to v0.0.30

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,7 @@
 # Building the demo app
 
 Create a new file `local.properties`:
+
 ```
 EVERVAULT_APP_ID=<YOUR_EVERVAULT_APP_ID>
 EVERVAULT_MERCHANT_ID=<YOUR_EVERVAULT_MERCHANT_ID>
@@ -9,3 +10,8 @@ EVERVAULT_MERCHANT_ID=<YOUR_EVERVAULT_MERCHANT_ID>
 ```bash
 ./gradlew build
 ```
+
+## Releasing a new version
+
+1. Bump the version in the `googlepay/build.gradle.kts` file
+2. Create a new release in the GitHub repository with the tag `android-v<VERSION>`

--- a/android/googlepay/build.gradle.kts
+++ b/android/googlepay/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.evervault.payments" // Maven group ID
-version = "android-v0.0.27" // Bump per release
+version = "android-v0.0.30" // Bump per release
 
 android {
     namespace = "com.evervault.payments"


### PR DESCRIPTION
## Why

I had pushed a tag for v0.0.29 but this did not include the updated version in the build gradle.

I've also added README instructions on how to release a new version