### PR TITLE
Allow the merchant to request billing address & payer details across transaction types

### DIFF
--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -208,10 +208,11 @@ public class EvervaultPaymentView: UIView {
         paymentRequest.shippingType = transaction.shippingType
         paymentRequest.shippingMethods = transaction.shippingMethods
         paymentRequest.requiredShippingContactFields = transaction.requiredShippingContactFields
-        
+        paymentRequest.requiredBillingContactFields = transaction.requestPayerDetails
+
         return paymentRequest
     }
-    
+
     @available(iOS 17.0, *)
     private func buildPaymentRequest(transaction: DisbursementTransaction) -> PKDisbursementRequest {
         let paymentRequest = PKDisbursementRequest()
@@ -271,7 +272,8 @@ public class EvervaultPaymentView: UIView {
         recurring.trialBilling = transaction.trialBilling
         recurring.billingAgreement = transaction.billingAgreement
         paymentRequest.recurringPaymentRequest = recurring
-        
+        paymentRequest.requiredBillingContactFields = transaction.requestPayerDetails
+
         return paymentRequest
     }
     

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -79,14 +79,16 @@ public struct OneOffPaymentTransaction {
     public var shippingType: PKShippingType
     public var shippingMethods: [PKShippingMethod]
     public var requiredShippingContactFields: Set<ContactField>
+    public var requestPayerDetails: Set<ContactField>
 
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem]) throws {
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem], requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
         self.shippingType = .shipping
         self.shippingMethods = []
         self.requiredShippingContactFields = []
+        self.requestPayerDetails = requestPayerDetails
 
         // Ensure at least one line item is provided
         guard paymentSummaryItems.count > 0 else {
@@ -94,34 +96,36 @@ public struct OneOffPaymentTransaction {
         }
     }
 
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType, shippingMethods: [PKShippingMethod], requiredShippingContactFields: Set<ContactField>) throws {
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType, shippingMethods: [PKShippingMethod], requiredShippingContactFields: Set<ContactField>, requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
         self.shippingType = shippingType
         self.shippingMethods = shippingMethods
         self.requiredShippingContactFields = requiredShippingContactFields
+        self.requestPayerDetails = requestPayerDetails
 
         // Ensure at least one line item is provided
         guard paymentSummaryItems.count > 0 else {
             throw EvervaultError.InvalidTransactionError
         }
     }
-    
+
     @available(iOS 16, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem]) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem], requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
         self.shippingType = .shipping
         self.shippingMethods = []
         self.requiredShippingContactFields = []
+        self.requestPayerDetails = requestPayerDetails
 
         // Ensure at least one line item is provided
         guard paymentSummaryItems.count > 0 else {
             throw EvervaultError.InvalidTransactionError
         }
-        
+
         // Ensure valid currency
         guard currency.isISOCurrency else {
             throw EvervaultError.InvalidCurrencyError
@@ -131,21 +135,22 @@ public struct OneOffPaymentTransaction {
             throw EvervaultError.InvalidCountryError
         }
     }
-    
+
     @available(iOS 16, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType, shippingMethods: [PKShippingMethod], requiredShippingContactFields: Set<ContactField>) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType, shippingMethods: [PKShippingMethod], requiredShippingContactFields: Set<ContactField>, requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
         self.shippingType = shippingType
         self.shippingMethods = shippingMethods
         self.requiredShippingContactFields = requiredShippingContactFields
+        self.requestPayerDetails = requestPayerDetails
 
         // Ensure at least one line item is provided
         guard paymentSummaryItems.count > 0 else {
             throw EvervaultError.InvalidTransactionError
         }
-        
+
         // Ensure valid currency
         guard currency.isISOCurrency else {
             throw EvervaultError.InvalidCurrencyError
@@ -216,25 +221,28 @@ public struct RecurringPaymentTransaction {
     public var managementURL: URL
     public var trialBilling: PKRecurringPaymentSummaryItem?
     public var billingAgreement: String?
-    
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL) throws {
+    public var requestPayerDetails: Set<ContactField>
+
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
         self.paymentDescription = paymentDescription
         self.regularBilling = regularBilling
         self.managementURL = managementURL
+        self.requestPayerDetails = requestPayerDetails
     }
-    
+
     @available(iOS 16.0, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = []) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
         self.paymentDescription = paymentDescription
         self.regularBilling = regularBilling
         self.managementURL = managementURL
-        
+        self.requestPayerDetails = requestPayerDetails
+
         // Ensure valid currency
         guard currency.isISOCurrency else {
             throw EvervaultError.InvalidCurrencyError


### PR DESCRIPTION
Today: the iOS SDK never asks for billing contact, and only collects shipping contact fields on `one-off` transactions. `Recurring` sets no contact fields at all, and `disbursement` has its own recipient-details path. 
Web, by contrast, lets the merchant request billing address plus payer name/email/phone across transaction types.

Unlike web (`requestBillingAddress: boolean` + `requestPayerDetails: string[]`), iOS exposes a single `requestPayerDetails: Set<ContactField>` using PassKit's own PKContactField naming (.name, .emailAddress, .phoneNumber, .postalAddress, .phoneticName) rather than web's shortened field names.
This is functional parity (a merchant can request the same billing fields on both platforms), not literal API-shape parity, since the two SDKs have entirely different consumers and PassKit already has its own idiomatic representation for these fields.

Note: PassKit's native `requiredBillingAddressFields` was deprecated in iOS 11 in favor of `requiredBillingContactFields` (what this change uses) - https://developer.apple.com/documentation/passkit/pkpaymentrequest/requiredbillingaddressfields / https://developer.apple.com/documentation/passkit/pkpaymentrequest/requiredbillingcontactfields. 

Web's `requestBillingAddress` boolean is a separate, Safari-specific extension to the W3C PaymentRequest API, not the same deprecated native field - the two aren't directly related despite the similar naming.

#### Change: 
Expose payer contact options on the iOS transaction/config and map them onto the request's required billing contact fields for one-off and recurring.

#### Tested manually. 
- ` .postalAddress` field works as intended & includes First/Last Names
- `.phoneticName` will be shown if requested with `.postalAddress`
- `.name`, `.emailAddress`, `.phoneNumber` are not explicitly requested 

This seems to be Apple iOS SDK behaviour. Not much we can do about it on our side. 
It probably uses AppleID info instead of showing the form. However, SDK returns nil if no AppleID is registered with the device - https://developer.apple.com/forums/thread/61802

<img width="353" height="702" alt="Screenshot 2026-07-06 at 13 37 33" src="https://github.com/user-attachments/assets/483da8f8-96b6-4fac-bb19-716c472cc005" />
<img width="385" height="776" alt="Screenshot 2026-07-06 at 15 49 30" src="https://github.com/user-attachments/assets/f23723c9-6384-4bcc-9f42-ee9454884ae6" />
<img width="350" height="336" alt="Screenshot 2026-07-06 at 13 37 23" src="https://github.com/user-attachments/assets/8e94e430-77a5-4d4e-a4cc-2fb4905ff8ca" />
