### PR TITLE
Enrich ApplePayResponse with billing & shipping contact and transaction type

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -49,6 +49,28 @@ jobs:
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -sdk iphoneos CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
 
+  Test-Package:
+    name: Test EvervaultPayment package
+    runs-on: macos-15
+    env:
+      DEVICE_NAME: "iPhone 16"
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Boot simulator
+        run: |
+          xcrun simctl list
+          xcrun simctl boot "$DEVICE_NAME"
+          xcrun simctl bootstatus "$DEVICE_NAME"
+      - name: Test
+        env:
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          xcodebuild test -scheme EvervaultPayment -destination "platform=$platform,name=$DEVICE_NAME"
+
   Build-Simulator:
     name: Build and Test default scheme using any available iPhone simulator
     runs-on: macos-15

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,11 @@ let package = Package(
     .target(
       name: "EvervaultPayment",
       path: "ios/EvervaultPayment"
+    ),
+    .testTarget(
+      name: "EvervaultPaymentTests",
+      dependencies: ["EvervaultPayment"],
+      path: "ios/EvervaultPaymentTests"
     )
   ]
 )

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -303,9 +303,14 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
         do {
             // Send the token to the Evervault backend for decryption and re-encryption with Evervault Encryption
             let decoded = try await EvervaultApi.sendPaymentToken(appUuid, payment)
+            let enriched = decoded?.enriched(
+                billingContact: ApplePayContact(payment.billingContact),
+                shippingContact: ApplePayContact(payment.shippingContact),
+                transactionType: ApplePayTransactionType(self.transaction)
+            )
             await MainActor.run {
                 // Notify the delegate on the main actor
-                self.delegate?.evervaultPaymentView(self, didAuthorizePayment: decoded)
+                self.delegate?.evervaultPaymentView(self, didAuthorizePayment: enriched)
             }
             
             // Tell Apple Pay the payment was successful

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -303,10 +303,11 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
         do {
             // Send the token to the Evervault backend for decryption and re-encryption with Evervault Encryption
             let decoded = try await EvervaultApi.sendPaymentToken(appUuid, payment)
+            let transactionType = await MainActor.run { ApplePayTransactionType(self.transaction) }
             let enriched = decoded?.enriched(
                 billingContact: ApplePayContact(payment.billingContact),
                 shippingContact: ApplePayContact(payment.shippingContact),
-                transactionType: ApplePayTransactionType(self.transaction)
+                transactionType: transactionType
             )
             await MainActor.run {
                 // Notify the delegate on the main actor

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -1,5 +1,6 @@
 import PassKit
 import Foundation
+import Contacts
 
 public typealias Network = PKPaymentNetwork
 
@@ -41,6 +42,62 @@ public struct ApplePayCard: Codable, Sendable, Equatable {
     public let issuer: String?
 }
 
+public struct ApplePayPostalAddress: Codable, Sendable, Equatable {
+    public let street: String?
+    public let city: String?
+    public let state: String?
+    public let postalCode: String?
+    public let country: String?
+    public let isoCountryCode: String?
+
+    init(_ address: CNPostalAddress) {
+        self.street = address.street.isEmpty ? nil : address.street
+        self.city = address.city.isEmpty ? nil : address.city
+        self.state = address.state.isEmpty ? nil : address.state
+        self.postalCode = address.postalCode.isEmpty ? nil : address.postalCode
+        self.country = address.country.isEmpty ? nil : address.country
+        self.isoCountryCode = address.isoCountryCode.isEmpty ? nil : address.isoCountryCode
+    }
+}
+
+public struct ApplePayContact: Codable, Sendable, Equatable {
+    public let givenName: String?
+    public let familyName: String?
+    public let phoneticGivenName: String?
+    public let phoneticFamilyName: String?
+    public let emailAddress: String?
+    public let phoneNumber: String?
+    public let postalAddress: ApplePayPostalAddress?
+
+    init?(_ contact: PKContact?) {
+        guard let contact else { return nil }
+        self.givenName = contact.name?.givenName
+        self.familyName = contact.name?.familyName
+        self.phoneticGivenName = contact.name?.phoneticRepresentation?.givenName
+        self.phoneticFamilyName = contact.name?.phoneticRepresentation?.familyName
+        self.emailAddress = contact.emailAddress
+        self.phoneNumber = contact.phoneNumber?.stringValue
+        self.postalAddress = contact.postalAddress.map(ApplePayPostalAddress.init)
+    }
+}
+
+public enum ApplePayTransactionType: String, Codable, Sendable, Equatable {
+    case oneOff
+    case recurring
+    case disbursement
+
+    init(_ transaction: Transaction) {
+        switch transaction {
+        case .oneOffPayment:
+            self = .oneOff
+        case .recurringPayment:
+            self = .recurring
+        case .disbursement:
+            self = .disbursement
+        }
+    }
+}
+
 public struct ApplePayResponse: Codable, Sendable, Equatable {
     public let networkToken: ApplePayNetworkToken
     public let card: ApplePayCard
@@ -48,6 +105,35 @@ public struct ApplePayResponse: Codable, Sendable, Equatable {
     public let eci: String?
     public let paymentDataType: String
     public let deviceManufacturerIdentifier: String
+    public let billingContact: ApplePayContact?
+    public let shippingContact: ApplePayContact?
+    public let transactionType: ApplePayTransactionType?
+
+    init(networkToken: ApplePayNetworkToken, card: ApplePayCard, cryptogram: String, eci: String?, paymentDataType: String, deviceManufacturerIdentifier: String, billingContact: ApplePayContact? = nil, shippingContact: ApplePayContact? = nil, transactionType: ApplePayTransactionType? = nil) {
+        self.networkToken = networkToken
+        self.card = card
+        self.cryptogram = cryptogram
+        self.eci = eci
+        self.paymentDataType = paymentDataType
+        self.deviceManufacturerIdentifier = deviceManufacturerIdentifier
+        self.billingContact = billingContact
+        self.shippingContact = shippingContact
+        self.transactionType = transactionType
+    }
+
+    func enriched(billingContact: ApplePayContact?, shippingContact: ApplePayContact?, transactionType: ApplePayTransactionType) -> ApplePayResponse {
+        ApplePayResponse(
+            networkToken: networkToken,
+            card: card,
+            cryptogram: cryptogram,
+            eci: eci,
+            paymentDataType: paymentDataType,
+            deviceManufacturerIdentifier: deviceManufacturerIdentifier,
+            billingContact: billingContact,
+            shippingContact: shippingContact,
+            transactionType: transactionType
+        )
+    }
 }
 
 /// Amount wrapper around NSDecimalNumber

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -42,6 +42,11 @@ public struct ApplePayCard: Codable, Sendable, Equatable {
     public let issuer: String?
 }
 
+private func nilIfEmpty(_ value: String?) -> String? {
+    guard let value, !value.isEmpty else { return nil }
+    return value
+}
+
 public struct ApplePayPostalAddress: Codable, Sendable, Equatable {
     public let street: String?
     public let city: String?
@@ -51,12 +56,12 @@ public struct ApplePayPostalAddress: Codable, Sendable, Equatable {
     public let isoCountryCode: String?
 
     init(_ address: CNPostalAddress) {
-        self.street = address.street.isEmpty ? nil : address.street
-        self.city = address.city.isEmpty ? nil : address.city
-        self.state = address.state.isEmpty ? nil : address.state
-        self.postalCode = address.postalCode.isEmpty ? nil : address.postalCode
-        self.country = address.country.isEmpty ? nil : address.country
-        self.isoCountryCode = address.isoCountryCode.isEmpty ? nil : address.isoCountryCode
+        self.street = nilIfEmpty(address.street)
+        self.city = nilIfEmpty(address.city)
+        self.state = nilIfEmpty(address.state)
+        self.postalCode = nilIfEmpty(address.postalCode)
+        self.country = nilIfEmpty(address.country)
+        self.isoCountryCode = nilIfEmpty(address.isoCountryCode)
     }
 }
 
@@ -71,12 +76,12 @@ public struct ApplePayContact: Codable, Sendable, Equatable {
 
     init?(_ contact: PKContact?) {
         guard let contact else { return nil }
-        self.givenName = contact.name?.givenName
-        self.familyName = contact.name?.familyName
-        self.phoneticGivenName = contact.name?.phoneticRepresentation?.givenName
-        self.phoneticFamilyName = contact.name?.phoneticRepresentation?.familyName
-        self.emailAddress = contact.emailAddress
-        self.phoneNumber = contact.phoneNumber?.stringValue
+        self.givenName = nilIfEmpty(contact.name?.givenName)
+        self.familyName = nilIfEmpty(contact.name?.familyName)
+        self.phoneticGivenName = nilIfEmpty(contact.name?.phoneticRepresentation?.givenName)
+        self.phoneticFamilyName = nilIfEmpty(contact.name?.phoneticRepresentation?.familyName)
+        self.emailAddress = nilIfEmpty(contact.emailAddress)
+        self.phoneNumber = nilIfEmpty(contact.phoneNumber?.stringValue)
         self.postalAddress = contact.postalAddress.map(ApplePayPostalAddress.init)
     }
 }

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+import Contacts
+import PassKit
+@testable import EvervaultPayment
+
+final class ApplePayContactTests: XCTestCase {
+    func testNilContactReturnsNil() {
+        XCTAssertNil(ApplePayContact(nil))
+    }
+
+    func testMapsAllFieldsIncludingPhoneticNameAndAddress() {
+        let contact = PKContact()
+
+        var name = PersonNameComponents()
+        name.givenName = "Taro"
+        name.familyName = "Yamada"
+        var phonetic = PersonNameComponents()
+        phonetic.givenName = "たろう"
+        phonetic.familyName = "やまだ"
+        name.phoneticRepresentation = phonetic
+        contact.name = name
+
+        contact.emailAddress = "taro@example.com"
+        contact.phoneNumber = CNPhoneNumber(stringValue: "+15555550100")
+
+        let address = CNMutablePostalAddress()
+        address.street = "1 Main St"
+        address.city = "Dublin"
+        address.state = "Leinster"
+        address.postalCode = "D01"
+        address.country = "Ireland"
+        address.isoCountryCode = "IE"
+        contact.postalAddress = address
+
+        let result = ApplePayContact(contact)
+
+        XCTAssertEqual(result?.givenName, "Taro")
+        XCTAssertEqual(result?.familyName, "Yamada")
+        XCTAssertEqual(result?.phoneticGivenName, "たろう")
+        XCTAssertEqual(result?.phoneticFamilyName, "やまだ")
+        XCTAssertEqual(result?.emailAddress, "taro@example.com")
+        XCTAssertEqual(result?.phoneNumber, "+15555550100")
+        XCTAssertEqual(result?.postalAddress?.street, "1 Main St")
+        XCTAssertEqual(result?.postalAddress?.city, "Dublin")
+        XCTAssertEqual(result?.postalAddress?.state, "Leinster")
+        XCTAssertEqual(result?.postalAddress?.postalCode, "D01")
+        XCTAssertEqual(result?.postalAddress?.country, "Ireland")
+        XCTAssertEqual(result?.postalAddress?.isoCountryCode, "IE")
+    }
+
+    func testMissingFieldsMapToNil() {
+        let contact = PKContact()
+        contact.emailAddress = "only-email@example.com"
+
+        let result = ApplePayContact(contact)
+
+        XCTAssertEqual(result?.emailAddress, "only-email@example.com")
+        XCTAssertNil(result?.givenName)
+        XCTAssertNil(result?.familyName)
+        XCTAssertNil(result?.phoneticGivenName)
+        XCTAssertNil(result?.phoneticFamilyName)
+        XCTAssertNil(result?.phoneNumber)
+        XCTAssertNil(result?.postalAddress)
+    }
+
+    func testEmptyPostalAddressFieldsCollapseToNil() {
+        let contact = PKContact()
+        contact.postalAddress = CNMutablePostalAddress()
+
+        let result = ApplePayContact(contact)
+
+        XCTAssertNotNil(result?.postalAddress)
+        XCTAssertNil(result?.postalAddress?.street)
+        XCTAssertNil(result?.postalAddress?.city)
+        XCTAssertNil(result?.postalAddress?.state)
+        XCTAssertNil(result?.postalAddress?.postalCode)
+        XCTAssertNil(result?.postalAddress?.country)
+        XCTAssertNil(result?.postalAddress?.isoCountryCode)
+    }
+}
+
+final class ApplePayTransactionTypeTests: XCTestCase {
+    func testMapsOneOffPayment() throws {
+        let transaction = Transaction.oneOffPayment(try OneOffPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentSummaryItems: [SummaryItem(label: "Total", amount: Amount("10.00"))]
+        ))
+
+        XCTAssertEqual(ApplePayTransactionType(transaction), .oneOff)
+    }
+
+    func testMapsRecurringPayment() throws {
+        let transaction = Transaction.recurringPayment(try RecurringPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentDescription: "Subscription",
+            regularBilling: PKRecurringPaymentSummaryItem(label: "Monthly", amount: NSDecimalNumber(string: "10.00")),
+            managementURL: URL(string: "https://example.com/manage")!
+        ))
+
+        XCTAssertEqual(ApplePayTransactionType(transaction), .recurring)
+    }
+
+    func testMapsDisbursement() throws {
+        let transaction = Transaction.disbursement(try DisbursementTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentSummaryItems: [SummaryItem(label: "Total", amount: Amount("10.00"))],
+            disbursementItem: SummaryItem(label: "Payout", amount: Amount("10.00")),
+            requiredRecipientDetails: [],
+            merchantCapability: .capability3DS
+        ))
+
+        XCTAssertEqual(ApplePayTransactionType(transaction), .disbursement)
+    }
+}
+
+final class ApplePayResponseEnrichedTests: XCTestCase {
+    private func makeBaseResponse() -> ApplePayResponse {
+        ApplePayResponse(
+            networkToken: ApplePayNetworkToken(
+                number: "ev:abc",
+                expiry: ApplePayNetworkTokenExpiry(month: 12, year: 30),
+                rawExpiry: "12/30",
+                tokenServiceProvider: "Apple"
+            ),
+            card: ApplePayCard(brand: "visa", funding: "debit", segment: "consumer", country: "ie", currency: "eur", issuer: "Bank"),
+            cryptogram: "ev:cryptogram",
+            eci: "5",
+            paymentDataType: "3DSecure",
+            deviceManufacturerIdentifier: "device-id"
+        )
+    }
+
+    private func makeContact(givenName: String) -> PKContact {
+        let contact = PKContact()
+        var name = PersonNameComponents()
+        name.givenName = givenName
+        contact.name = name
+        return contact
+    }
+
+    func testEnrichedPreservesBackendFieldsAndSetsNewOnes() {
+        let base = makeBaseResponse()
+        let billingContact = ApplePayContact(makeContact(givenName: "John"))
+        let shippingContact = ApplePayContact(makeContact(givenName: "Jane"))
+
+        let enriched = base.enriched(billingContact: billingContact, shippingContact: shippingContact, transactionType: .oneOff)
+
+        XCTAssertEqual(enriched.networkToken, base.networkToken)
+        XCTAssertEqual(enriched.card, base.card)
+        XCTAssertEqual(enriched.cryptogram, base.cryptogram)
+        XCTAssertEqual(enriched.eci, base.eci)
+        XCTAssertEqual(enriched.paymentDataType, base.paymentDataType)
+        XCTAssertEqual(enriched.deviceManufacturerIdentifier, base.deviceManufacturerIdentifier)
+
+        XCTAssertNil(base.billingContact)
+        XCTAssertNil(base.shippingContact)
+        XCTAssertNil(base.transactionType)
+
+        XCTAssertEqual(enriched.billingContact?.givenName, "John")
+        XCTAssertEqual(enriched.shippingContact?.givenName, "Jane")
+        XCTAssertEqual(enriched.transactionType, .oneOff)
+    }
+
+    func testEnrichedWithNilContactsKeepsThemNil() {
+        let base = makeBaseResponse()
+
+        let enriched = base.enriched(billingContact: nil, shippingContact: nil, transactionType: .disbursement)
+
+        XCTAssertNil(enriched.billingContact)
+        XCTAssertNil(enriched.shippingContact)
+        XCTAssertEqual(enriched.transactionType, .disbursement)
+    }
+}

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -48,6 +48,25 @@ final class ApplePayContactTests: XCTestCase {
         XCTAssertEqual(result?.postalAddress?.isoCountryCode, "IE")
     }
 
+    func testEmptyPhoneticNameCollapsesToNil() {
+        let contact = PKContact()
+
+        var name = PersonNameComponents()
+        name.givenName = "Ana"
+        name.familyName = "M"
+        // Simulator's synthetic Apple Pay test contact hands back a non-nil
+        // phoneticRepresentation with empty fields rather than nil outright.
+        name.phoneticRepresentation = PersonNameComponents()
+        contact.name = name
+
+        let result = ApplePayContact(contact)
+
+        XCTAssertEqual(result?.givenName, "Ana")
+        XCTAssertEqual(result?.familyName, "M")
+        XCTAssertNil(result?.phoneticGivenName)
+        XCTAssertNil(result?.phoneticFamilyName)
+    }
+
     func testMissingFieldsMapToNil() {
         let contact = PKContact()
         contact.emailAddress = "only-email@example.com"

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -67,6 +67,24 @@ final class ApplePayContactTests: XCTestCase {
         XCTAssertNil(result?.phoneticFamilyName)
     }
 
+    func testEmptyNameEmailAndPhoneCollapseToNil() {
+        let contact = PKContact()
+
+        var name = PersonNameComponents()
+        name.givenName = ""
+        name.familyName = ""
+        contact.name = name
+        contact.emailAddress = ""
+        contact.phoneNumber = CNPhoneNumber(stringValue: "")
+
+        let result = ApplePayContact(contact)
+
+        XCTAssertNil(result?.givenName)
+        XCTAssertNil(result?.familyName)
+        XCTAssertNil(result?.emailAddress)
+        XCTAssertNil(result?.phoneNumber)
+    }
+
     func testMissingFieldsMapToNil() {
         let contact = PKContact()
         contact.emailAddress = "only-email@example.com"
@@ -191,5 +209,28 @@ final class ApplePayResponseEnrichedTests: XCTestCase {
         XCTAssertNil(enriched.billingContact)
         XCTAssertNil(enriched.shippingContact)
         XCTAssertEqual(enriched.transactionType, .disbursement)
+    }
+}
+
+final class ApplePayResponseDecodingTests: XCTestCase {
+    func testDecodesBackendJSONWithoutNewFields() throws {
+        let json = """
+        {
+          "networkToken": {"number": "ev:abc", "expiry": {"month": "12", "year": "30"}, "rawExpiry": "12/30", "tokenServiceProvider": "Apple"},
+          "card": {"brand": "visa"},
+          "cryptogram": "ev:cryptogram",
+          "eci": "5",
+          "paymentDataType": "3DSecure",
+          "deviceManufacturerIdentifier": "device-id"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ApplePayResponse.self, from: json)
+
+        XCTAssertEqual(decoded.networkToken.number, "ev:abc")
+        XCTAssertEqual(decoded.card.brand, "visa")
+        XCTAssertNil(decoded.billingContact)
+        XCTAssertNil(decoded.shippingContact)
+        XCTAssertNil(decoded.transactionType)
     }
 }


### PR DESCRIPTION
**Today:** the iOS result carries the network token, card metadata, cryptogram, ECI, and a payment-data-type string — but it drops the billing/shipping contact PassKit provides and exposes no transactionType. 
Web already merges contact data client-side off the browser payment response and adds transactionType.

**Change:** read the billing/shipping contact off the authorized payment and add a client-derived transactionType (oneOff/recurring/disbursement) to the iOS result. 
Backend stays untouched — it never returned these for either client.

**Risk/notes:** low; the shape just needs to line up field-for-field with web's result so a cross-platform consumer sees the same object. Pairs naturally with the A contact work.

Tested manually - all works 