### PR TITLE
Fix GitHub advanced security bot warnings

### DIFF
--- a/.github/workflows/cocoapods-deploy.yml
+++ b/.github/workflows/cocoapods-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Update Specs Repo

--- a/.github/workflows/cocoapods-deploy.yml
+++ b/.github/workflows/cocoapods-deploy.yml
@@ -5,6 +5,9 @@ on:
     tags-ignore:
       - 'android-*'
 
+permissions:
+  contents: read
+
 jobs:
   Deploy:
     name: Publish

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -7,6 +7,9 @@ on:
       - '.github/**'
       - '**/*.podspec'
 
+permissions:
+  contents: read
+
 jobs:
   Pod-Lint:
     name: Cocoapods Lint

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Update Specs Repo
@@ -26,7 +26,7 @@ jobs:
     name: Build Device
     runs-on: macos-15
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
         working-directory: ios/Demo/Demo
         run: |
           echo "$IOS_TEST_ENTITLEMENTS_CONTENTS" > DemoDebug.entitlements
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Build
@@ -55,7 +55,7 @@ jobs:
     env:
       DEVICE_NAME: "iPhone 16"
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
     env:
       DEVICE_NAME: "iPhone 16"
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Checkout
@@ -86,7 +86,7 @@ jobs:
         working-directory: ios/Demo/Demo
         run: |
           echo "$IOS_TEST_ENTITLEMENTS_CONTENTS" > DemoDebug.entitlements
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Boot simulator


### PR DESCRIPTION
Noticed them when was updating iOS workflow - created a separate PR to resolve 👀 


`github-actions` is tracked by Dependabot on a weekly schedule. Dependabot understands pinned SHAs and will automatically open a PR bumping to the new commit (with an updated # vX.Y.Z comment) whenever a new release ships.