### PR TITLE
Bump iOS SDK version to 0.0.25

### DIFF
--- a/EvervaultPayment.podspec
+++ b/EvervaultPayment.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "EvervaultPayment"
-  spec.version      = "0.0.24"
+  spec.version      = "0.0.25"
   spec.summary      = "Evervault Pay SDK for iOS - Secure Apple Pay integration with Evervault encryption"
   spec.description  = <<-DESC
     The Evervault Pay SDK for iOS provides a secure way to integrate Apple Pay into your iOS applications.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ For the most up-to-date documentation, visit the SDK references on Evervault for
 
 This project includes sample applications for both Apple Pay and Google Pay in their respective directories. 
 
+## Releasing a new version
+
+See the platform-specific release instructions:
+
+* [iOS](ios/README.md#releasing-a-new-version)
+* [Android](android/README.md#releasing-a-new-version)
+
 ## Contributing
 Bug reports and pull requests are welcome on GitHub at https://github.com/evervault/evervault-pay/issues.
 

--- a/android/README.md
+++ b/android/README.md
@@ -13,5 +13,6 @@ EVERVAULT_MERCHANT_ID=<YOUR_EVERVAULT_MERCHANT_ID>
 
 ## Releasing a new version
 
-1. Bump the version in the `googlepay/build.gradle.kts` file
-2. Create a new release in the GitHub repository with the tag `android-v<VERSION>`
+1. Bump the version in the `googlepay/build.gradle.kts` file (could be done in the same PR as your change, or as its own separate version-bump PR — there's no technical requirement either way; a separate PR just lets you batch several merged changes into one release instead of releasing on every merge)
+2. Merge that change to `main`
+3. Create a new release in the GitHub repository with the tag `android-v<VERSION>` (e.g. `android-v0.0.31`) — the `android-` prefix is required, not just a naming convention: [`jitpack.yml`](../jitpack.yml) explicitly refuses to build any tag that doesn't start with `android-`, and the iOS [Cocoapods workflow](../.github/workflows/cocoapods-deploy.yml) triggers on *any* pushed tag except ones prefixed `android-`. Getting the prefix wrong means Android consumers can't resolve the release **and** risks accidentally kicking off an unrelated iOS publish attempt.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,12 @@
+## Releasing a new version
+
+1. Bump `spec.version` in [`EvervaultPayment.podspec`](../EvervaultPayment.podspec) (could be done in the same PR as your change, or as its own separate version-bump PR — there's no technical requirement either way; a separate PR just lets you batch several merged changes into one release instead of releasing on every merge)
+2. Merge that change to `main`
+3. Push a tag matching the new version **exactly** (e.g. `0.0.25` — not `v0.0.25`, not `ios-v0.0.25`) on the commit on `main` that has the version bump:
+   ```bash
+   git checkout main
+   git pull
+   git tag 0.0.25
+   git push origin 0.0.25
+   ```
+   This triggers the [Cocoapods workflow](../.github/workflows/cocoapods-deploy.yml) to publish to CocoaPods trunk, and is also what Swift Package Manager resolves versions against directly (no separate SPM publish step is needed). The exact naming matters: this repo also has `android-v*` and legacy `ios-v*` tags for other purposes — neither CocoaPods nor SPM will recognize those formats, so a wrongly-named tag looks like a successful push but silently releases nothing.


### PR DESCRIPTION
SDK now allows to request  payer contact info & surfaces it to the customer
- https://linear.app/evervault/issue/CARD-871/a-request-config-passthrough-apple-pay-ios
- https://linear.app/evervault/issue/CARD-872/b-result-surface-parity-apple-pay-ios-web


Also updated READMEs with release-related info