### PR TITLE
Switch to using 3-state availability for APay

### DIFF
--- a/ios/Demo/Demo/ContentView.swift
+++ b/ios/Demo/Demo/ContentView.swift
@@ -142,18 +142,23 @@ struct TransactionHandler : View {
         self.transaction = buildTransaction(type: type)
     }
 
+    private let supportedNetworks: [Network] = [.visa, .masterCard, .amex]
+
     var body: some View {
+        let availability = EvervaultPaymentViewRepresentable.availability(supportedNetworks: supportedNetworks)
+
         VStack(spacing: 20) {
             Text(self.name)
             Spacer()
-            if EvervaultPaymentViewRepresentable.availability(supportedNetworks: [.visa, .masterCard, .amex]) != .unsupported {
+            if availability != .unsupported {
                 EvervaultPaymentViewRepresentable(
                     appId: "YOUR_EVERVAULT_APP_ID",
                     appleMerchantId: "YOUR_APPLE_MERCHANT_ID",
                     transaction: self.transaction,
-                    supportedNetworks: [.visa, .masterCard, .amex],
+                    supportedNetworks: supportedNetworks,
                     buttonStyle: .whiteOutline,
-                    buttonType: .checkout,
+                    // No provisioned card yet: prompt the user to set one up instead of a normal buy button.
+                    buttonType: availability == .unavailable ? .setUp : .checkout,
                     authorizedResponse: $applePayResponse) { result in
                         switch result {
                         case .success(_):

--- a/ios/Demo/Demo/ContentView.swift
+++ b/ios/Demo/Demo/ContentView.swift
@@ -146,7 +146,7 @@ struct TransactionHandler : View {
         VStack(spacing: 20) {
             Text(self.name)
             Spacer()
-            if EvervaultPaymentViewRepresentable.isAvailable() {
+            if EvervaultPaymentViewRepresentable.availability(supportedNetworks: [.visa, .masterCard, .amex]) != .unsupported {
                 EvervaultPaymentViewRepresentable(
                     appId: "YOUR_EVERVAULT_APP_ID",
                     appleMerchantId: "YOUR_APPLE_MERCHANT_ID",

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment+SwiftUI.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment+SwiftUI.swift
@@ -53,8 +53,16 @@ public struct EvervaultPaymentViewRepresentable: UIViewRepresentable {
     private var onPaymentMethodChangeCallback: ((_ paymentMethod: PKPaymentMethod) -> PKPaymentRequestPaymentMethodUpdate)?
     private var prepareTransactionCallback: ((_ transaction: inout Transaction) -> Void)?
 
+    @available(*, deprecated, message: "Use availability(supportedNetworks:) instead")
     public static func isAvailable() -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments()
+    }
+
+    /// Returns the three-state Apple Pay availability for the given supported card networks:
+    /// `.unsupported` if the device can't do Apple Pay at all, `.unavailable` if it can but has
+    /// no provisioned card on a supported network, `.available` otherwise.
+    public static func availability(supportedNetworks: [Network]) -> ApplePayAvailability {
+        return EvervaultPaymentView.availability(supportedNetworks: supportedNetworks)
     }
 
     public static func supportsDisbursements() -> Bool {

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -40,6 +40,13 @@ public enum EvervaultError: Error, LocalizedError {
     }
 }
 
+/// The three possible states of Apple Pay availability on a device.
+public enum ApplePayAvailability {
+    case available
+    case unavailable
+    case unsupported
+}
+
 // MARK: - Apple Pay View
 
 /// A UIView that wraps Apple Pay button and handles full payment flow.
@@ -54,7 +61,7 @@ public class EvervaultPaymentView: UIView {
     public weak var delegate: EvervaultPaymentViewDelegate? {
         didSet {
             // Verify Apple Pay is available on device
-            if !EvervaultPaymentView.isAvailable() {
+            if !PKPaymentAuthorizationViewController.canMakePayments() {
                 self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(.ApplePayUnavailableError))
             }
         }
@@ -102,8 +109,29 @@ public class EvervaultPaymentView: UIView {
     }
     
     /// Public check for Apple Pay availability
+    @available(*, deprecated, message: "Use availability(supportedNetworks:) instead")
     public static func isAvailable() -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments()
+    }
+
+    /// Returns the three-state Apple Pay availability for the given supported card networks:
+    /// `.unsupported` if the device can't do Apple Pay at all, `.unavailable` if it can but has
+    /// no provisioned card on a supported network, `.available` otherwise.
+    public static func availability(supportedNetworks: [Network]) -> ApplePayAvailability {
+        return evaluateAvailability(
+            canMakePayments: PKPaymentAuthorizationViewController.canMakePayments(),
+            canMakePaymentsWithNetworks: PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks)
+        )
+    }
+
+    static func evaluateAvailability(canMakePayments: Bool, canMakePaymentsWithNetworks: Bool) -> ApplePayAvailability {
+        if !canMakePayments {
+            return .unsupported
+        }
+        if !canMakePaymentsWithNetworks {
+            return .unavailable
+        }
+        return .available
     }
     
     // MARK: Layout

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -41,7 +41,7 @@ public enum EvervaultError: Error, LocalizedError {
 }
 
 /// The three possible states of Apple Pay availability on a device.
-public enum ApplePayAvailability {
+public enum ApplePayAvailability: Equatable {
     case available
     case unavailable
     case unsupported

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -119,16 +119,16 @@ public class EvervaultPaymentView: UIView {
     /// no provisioned card on a supported network, `.available` otherwise.
     public static func availability(supportedNetworks: [Network]) -> ApplePayAvailability {
         return evaluateAvailability(
-            canMakePayments: PKPaymentAuthorizationViewController.canMakePayments(),
-            canMakePaymentsWithNetworks: PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks)
+            deviceSupportsApplePay: PKPaymentAuthorizationViewController.canMakePayments(),
+            hasCardForSupportedNetworks: PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks)
         )
     }
 
-    static func evaluateAvailability(canMakePayments: Bool, canMakePaymentsWithNetworks: Bool) -> ApplePayAvailability {
-        if !canMakePayments {
+    static func evaluateAvailability(deviceSupportsApplePay: Bool, hasCardForSupportedNetworks: Bool) -> ApplePayAvailability {
+        if !deviceSupportsApplePay {
             return .unsupported
         }
-        if !canMakePaymentsWithNetworks {
+        if !hasCardForSupportedNetworks {
             return .unavailable
         }
         return .available

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -41,7 +41,7 @@ public enum EvervaultError: Error, LocalizedError {
 }
 
 /// The three possible states of Apple Pay availability on a device.
-public enum ApplePayAvailability: Equatable {
+public enum ApplePayAvailability: String, Codable, Sendable, Equatable {
     case available
     case unavailable
     case unsupported

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -234,3 +234,25 @@ final class ApplePayResponseDecodingTests: XCTestCase {
         XCTAssertNil(decoded.transactionType)
     }
 }
+
+final class ApplePayAvailabilityTests: XCTestCase {
+    func testUnsupportedWhenDeviceCannotMakePayments() {
+        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: false, canMakePaymentsWithNetworks: false)
+        XCTAssertEqual(availability, .unsupported)
+    }
+
+    func testUnsupportedWhenDeviceCannotMakePaymentsEvenIfNetworksMatch() {
+        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: false, canMakePaymentsWithNetworks: true)
+        XCTAssertEqual(availability, .unsupported)
+    }
+
+    func testUnavailableWhenDeviceSupportsButHasNoProvisionedCard() {
+        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: true, canMakePaymentsWithNetworks: false)
+        XCTAssertEqual(availability, .unavailable)
+    }
+
+    func testAvailableWhenDeviceSupportsAndHasProvisionedCard() {
+        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: true, canMakePaymentsWithNetworks: true)
+        XCTAssertEqual(availability, .available)
+    }
+}

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -237,22 +237,22 @@ final class ApplePayResponseDecodingTests: XCTestCase {
 
 final class ApplePayAvailabilityTests: XCTestCase {
     func testUnsupportedWhenDeviceCannotMakePayments() {
-        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: false, canMakePaymentsWithNetworks: false)
+        let availability = EvervaultPaymentView.evaluateAvailability(deviceSupportsApplePay: false, hasCardForSupportedNetworks: false)
         XCTAssertEqual(availability, .unsupported)
     }
 
     func testUnsupportedWhenDeviceCannotMakePaymentsEvenIfNetworksMatch() {
-        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: false, canMakePaymentsWithNetworks: true)
+        let availability = EvervaultPaymentView.evaluateAvailability(deviceSupportsApplePay: false, hasCardForSupportedNetworks: true)
         XCTAssertEqual(availability, .unsupported)
     }
 
     func testUnavailableWhenDeviceSupportsButHasNoProvisionedCard() {
-        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: true, canMakePaymentsWithNetworks: false)
+        let availability = EvervaultPaymentView.evaluateAvailability(deviceSupportsApplePay: true, hasCardForSupportedNetworks: false)
         XCTAssertEqual(availability, .unavailable)
     }
 
     func testAvailableWhenDeviceSupportsAndHasProvisionedCard() {
-        let availability = EvervaultPaymentView.evaluateAvailability(canMakePayments: true, canMakePaymentsWithNetworks: true)
+        let availability = EvervaultPaymentView.evaluateAvailability(deviceSupportsApplePay: true, hasCardForSupportedNetworks: true)
         XCTAssertEqual(availability, .available)
     }
 }


### PR DESCRIPTION
https://linear.app/evervault/issue/CARD-873/c-availability-and-signal-parity-apple-pay-ios

**Today:** iOS returns a plain boolean for "can do Apple Pay." Web returns three states — available, unavailable (device supports Apple Pay but has no provisioned card), and unsupported.

**Change:** return the same three-state result on iOS using the device capability check that distinguishes "no cards" from "not supported." Bridge or deprecate the existing boolean.

**Testing:** can't replicate the real "device supports Apple Pay, no card" condition, since Simulator creates a simulated card that matches supportedNetwork & it's not something that we can control.
It does present cards for the exact networks listed. With that and the test coverage i"d say we should be good to go.
Could be tested with a real device, but I don't think it makes sense.

External docs changes: https://github.com/evervault/docs/pull/727

We're planning to introduce some breaking changes next week. 
@deprecated method could be deleted as a part of that change, or we can stick with it for a bit longer.

**Unsupported vs unavailable:**
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-09 at 12 32 44" src="https://github.com/user-attachments/assets/5b6de740-64f7-46f1-aa15-b0120a428e12" /> <img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-09 at 12 31 56" src="https://github.com/user-attachments/assets/afca6b53-29ab-4bc2-bdf1-045ce2b16358" />