### PR TITLE
Distinct cancel vs success 

### DIFF
--- a/ios/Demo/Demo/ContentView.swift
+++ b/ios/Demo/Demo/ContentView.swift
@@ -162,7 +162,7 @@ struct TransactionHandler : View {
                     authorizedResponse: $applePayResponse) { result in
                         switch result {
                         case .success(_):
-                            print("Payment sheet dismissed")
+                            print("Payment sheet dismissed with success")
                             if (applePayResponse != nil) {
                                 // Send to PSP via Relay on your backend
                             }
@@ -176,6 +176,8 @@ struct TransactionHandler : View {
                         return getUpdatedTransaction(newAddress, transaction: self.transaction)
                     }.prepareTransaction { transaction in
                         print("Preparing transaction")
+                    }.onCancel {
+                        print("Payment sheet cancelled")
                     }
             } else {
                 Text("Not available")

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment+SwiftUI.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment+SwiftUI.swift
@@ -52,6 +52,7 @@ public struct EvervaultPaymentViewRepresentable: UIViewRepresentable {
     private var onShippingAddressChangeCallback: ((_ shippingContact: PKContact) -> [SummaryItem])?
     private var onPaymentMethodChangeCallback: ((_ paymentMethod: PKPaymentMethod) -> PKPaymentRequestPaymentMethodUpdate)?
     private var prepareTransactionCallback: ((_ transaction: inout Transaction) -> Void)?
+    private var onCancelCallback: (() -> Void)?
 
     @available(*, deprecated, message: "Use availability(supportedNetworks:) instead")
     public static func isAvailable() -> Bool {
@@ -121,6 +122,12 @@ public struct EvervaultPaymentViewRepresentable: UIViewRepresentable {
             }
         }
 
+        nonisolated public func evervaultPaymentViewDidCancel(_ view: EvervaultPaymentView) {
+            DispatchQueue.main.async {
+                self.parent.onCancelCallback?()
+            }
+        }
+
         nonisolated public func evervaultPaymentView(_ view: EvervaultPaymentView, didSelectShippingContact contact: PKContact) async -> PKPaymentRequestShippingContactUpdate? {
             if let handler = await self.parent.onShippingAddressChangeCallback {
                 let updatedLineItems = handler(contact)
@@ -178,6 +185,13 @@ public struct EvervaultPaymentViewRepresentable: UIViewRepresentable {
     public func onPaymentMethodChange(_ action: @escaping (PKPaymentMethod) -> PKPaymentRequestPaymentMethodUpdate) -> EvervaultPaymentViewRepresentable {
         var copy = self
         copy.onPaymentMethodChangeCallback = action
+        return copy
+    }
+
+    /// Called when the buyer dismisses the sheet without ever authorizing a payment, distinct from `onResult`'s success/failure.
+    public func onCancel(_ action: @escaping () -> Void) -> EvervaultPaymentViewRepresentable {
+        var copy = self
+        copy.onCancelCallback = action
         return copy
     }
 }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -370,7 +370,16 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
     nonisolated public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         DispatchQueue.main.async { [weak self] in
             if let self = self {
-                self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
+                switch self.tapAuthorizationOutcome {
+                case .success:
+                    self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
+                case .failure:
+                    // Already reported at the point of failure.
+                    break
+                case .none:
+                    // The sheet was closed without an authorization attempt ever completing: a genuine cancel.
+                    self.delegate?.evervaultPaymentViewDidCancel(self)
+                }
             }
             controller.dismiss(animated: true)
         }
@@ -405,7 +414,10 @@ public protocol EvervaultPaymentViewDelegate : AnyObject {
     
     /// Fired when the payment sheet is fully dismissed
     func evervaultPaymentView(_ view: EvervaultPaymentView, didFinishWithResult result: Result<Void, EvervaultError>)
-    
+
+    /// Fired when the buyer dismisses the sheet without ever authorizing a payment (e.g. taps Cancel), distinct from `didFinishWithResult`'s success/failure.
+    func evervaultPaymentViewDidCancel(_ view: EvervaultPaymentView)
+
     /// Called after the user taps the Apple Pay button, but before the modal is displayed.  The delegate can modify the transaction in-place.
     func evervaultPaymentView(_ view: EvervaultPaymentView, prepareTransaction transaction: inout Transaction)
 }
@@ -415,11 +427,15 @@ extension EvervaultPaymentViewDelegate {
     public func evervaultPaymentView(_ view: EvervaultPaymentView, prepareTransaction transaction: inout Transaction) {
         // Do nothing
     }
-    
+
     func evervaultPaymentView(_ view: EvervaultPaymentView, didFinishWithResult result: Result<Void, EvervaultError>) {
         // Do nothing
     }
-    
+
+    public func evervaultPaymentViewDidCancel(_ view: EvervaultPaymentView) {
+        // Do nothing
+    }
+
     public func evervaultPaymentView(_ view: EvervaultPaymentView, didSelectShippingContact: PKContact) async -> PKPaymentRequestShippingContactUpdate? {
         return nil
     }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -57,7 +57,13 @@ public class EvervaultPaymentView: UIView {
     public let supportedNetworks: [Network]
     public let buttonType: ButtonType
     public let buttonStyle: ButtonStyle
-    
+
+    /// Outcome of the current authorization attempt for Apple Pay sheet (shown on tapping the pay button).
+    /// Reset to `nil` at the top of `didTapPay()`, before a new sheet is presented;
+    /// set to `.success`/`.failure` once `didAuthorizePayment` resolves. 
+    /// If still `nil` when the sheet finishes, the buyer dismissed it without ever authorizing — a genuine cancel.
+    private var tapAuthorizationOutcome: Result<Void, EvervaultError>?
+
     public weak var delegate: EvervaultPaymentViewDelegate? {
         didSet {
             // Verify Apple Pay is available on device
@@ -156,6 +162,9 @@ public class EvervaultPaymentView: UIView {
     
     /// Tapped handler to start the Apple Pay sheet
     @objc private func didTapPay() {
+        // Reset before a new attempt.
+        self.tapAuthorizationOutcome = nil
+
         // Update the transaction in place.
         self.delegate?.evervaultPaymentView(self, prepareTransaction: &self.transaction)
         

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -139,7 +139,27 @@ public class EvervaultPaymentView: UIView {
         }
         return .available
     }
-    
+
+    /// The verdict on how the current authorization attempt resolved, given how (or whether) `didAuthorizePayment` fired.
+    enum AuthorizationVerdict: Equatable {
+        case success
+        case cancelled
+        case failureAlreadyReported
+    }
+
+    /// Pure decision logic behind `paymentAuthorizationViewControllerDidFinish`, split out for testing without a live PassKit sheet.
+    static func authorizationVerdict(for outcome: Result<Void, EvervaultError>?) -> AuthorizationVerdict {
+        switch outcome {
+        case .success:
+            return .success
+        case .failure:
+            // Already reported at the point of failure.
+            return .failureAlreadyReported
+        case .none:
+            return .cancelled
+        }
+    }
+
     // MARK: Layout
     
     /// Set the intrinsic size of this component to the underlying button size
@@ -370,14 +390,12 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
     nonisolated public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         DispatchQueue.main.async { [weak self] in
             if let self = self {
-                switch self.tapAuthorizationOutcome {
+                switch EvervaultPaymentView.authorizationVerdict(for: self.tapAuthorizationOutcome) {
                 case .success:
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
-                case .failure:
-                    // Already reported at the point of failure.
+                case .failureAlreadyReported:
                     break
-                case .none:
-                    // The sheet was closed without an authorization attempt ever completing: a genuine cancel.
+                case .cancelled:
                     self.delegate?.evervaultPaymentViewDidCancel(self)
                 }
             }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -349,14 +349,17 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
             await MainActor.run {
                 // Notify the delegate on the main actor
                 self.delegate?.evervaultPaymentView(self, didAuthorizePayment: enriched)
+                self.tapAuthorizationOutcome = .success(())
             }
-            
+
             // Tell Apple Pay the payment was successful
             return PKPaymentAuthorizationResult(status: .success, errors: nil)
         } catch {
+            let evError = EvervaultError.ApplePayAuthorizationError(underlying: error)
             await MainActor.run {
                 // Notify the delegate on the main actor
-                self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(.ApplePayAuthorizationError(underlying: error)))
+                self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(evError))
+                self.tapAuthorizationOutcome = .failure(evError)
             }
             // On error, surface back to Apple Pay
             return PKPaymentAuthorizationResult(status: .failure, errors: [error])

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -256,3 +256,20 @@ final class ApplePayAvailabilityTests: XCTestCase {
         XCTAssertEqual(availability, .available)
     }
 }
+
+final class AuthorizationVerdictTests: XCTestCase {
+    func testSuccessWhenAuthorizationSucceeded() {
+        let verdict = EvervaultPaymentView.authorizationVerdict(for: .success(()))
+        XCTAssertEqual(verdict, .success)
+    }
+
+    func testFailureAlreadyReportedWhenAuthorizationFailed() {
+        let verdict = EvervaultPaymentView.authorizationVerdict(for: .failure(.ApplePayUnavailableError))
+        XCTAssertEqual(verdict, .failureAlreadyReported)
+    }
+
+    func testCancelledWhenNoAuthorizationAttemptCompleted() {
+        let verdict = EvervaultPaymentView.authorizationVerdict(for: nil)
+        XCTAssertEqual(verdict, .cancelled)
+    }
+}


### PR DESCRIPTION
**Today:** the iOS finish handler always reports success, so a buyer dismissing the sheet is indistinguishable from a completed payment. (Direct analogue of the swallowed-cancel issue Android had.)

**Change:** track whether an authorization actually occurred and surface a distinct cancel outcome when it didn't, matching web's cancel signal.

**External docs:** https://github.com/evervault/docs/pull/727

**Tested** manually + demo is updated