### PR TITLE
Expose transactionId to merchants

### DIFF
--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultApi.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultApi.swift
@@ -18,7 +18,8 @@ struct EvervaultApi {
                                 cryptogram: "ev:Tk9D:vUVeybXqrA9Ds4rZ...=:$",
                                 eci: "5",
                                 paymentDataType: "oneOff",
-                                deviceManufacturerIdentifier: "string")
+                                deviceManufacturerIdentifier: "string",
+                                transactionId: "5ee9e294a2e79032ca7529b2050c2a878187c54a54f07559cff8281fb9b4716c")
 #else
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -110,17 +110,19 @@ public struct ApplePayResponse: Codable, Sendable, Equatable {
     public let eci: String?
     public let paymentDataType: String
     public let deviceManufacturerIdentifier: String
+    public let transactionId: String?
     public let billingContact: ApplePayContact?
     public let shippingContact: ApplePayContact?
     public let transactionType: ApplePayTransactionType?
 
-    init(networkToken: ApplePayNetworkToken, card: ApplePayCard, cryptogram: String, eci: String?, paymentDataType: String, deviceManufacturerIdentifier: String, billingContact: ApplePayContact? = nil, shippingContact: ApplePayContact? = nil, transactionType: ApplePayTransactionType? = nil) {
+    init(networkToken: ApplePayNetworkToken, card: ApplePayCard, cryptogram: String, eci: String?, paymentDataType: String, deviceManufacturerIdentifier: String, transactionId: String? = nil, billingContact: ApplePayContact? = nil, shippingContact: ApplePayContact? = nil, transactionType: ApplePayTransactionType? = nil) {
         self.networkToken = networkToken
         self.card = card
         self.cryptogram = cryptogram
         self.eci = eci
         self.paymentDataType = paymentDataType
         self.deviceManufacturerIdentifier = deviceManufacturerIdentifier
+        self.transactionId = transactionId
         self.billingContact = billingContact
         self.shippingContact = shippingContact
         self.transactionType = transactionType
@@ -134,6 +136,7 @@ public struct ApplePayResponse: Codable, Sendable, Equatable {
             eci: eci,
             paymentDataType: paymentDataType,
             deviceManufacturerIdentifier: deviceManufacturerIdentifier,
+            transactionId: transactionId,
             billingContact: billingContact,
             shippingContact: shippingContact,
             transactionType: transactionType

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -166,7 +166,8 @@ final class ApplePayResponseEnrichedTests: XCTestCase {
             cryptogram: "ev:cryptogram",
             eci: "5",
             paymentDataType: "3DSecure",
-            deviceManufacturerIdentifier: "device-id"
+            deviceManufacturerIdentifier: "device-id",
+            transactionId: "test-transaction-id-abc123"
         )
     }
 
@@ -191,6 +192,7 @@ final class ApplePayResponseEnrichedTests: XCTestCase {
         XCTAssertEqual(enriched.eci, base.eci)
         XCTAssertEqual(enriched.paymentDataType, base.paymentDataType)
         XCTAssertEqual(enriched.deviceManufacturerIdentifier, base.deviceManufacturerIdentifier)
+        XCTAssertEqual(enriched.transactionId, base.transactionId)
 
         XCTAssertNil(base.billingContact)
         XCTAssertNil(base.shippingContact)
@@ -232,6 +234,25 @@ final class ApplePayResponseDecodingTests: XCTestCase {
         XCTAssertNil(decoded.billingContact)
         XCTAssertNil(decoded.shippingContact)
         XCTAssertNil(decoded.transactionType)
+        XCTAssertNil(decoded.transactionId)
+    }
+
+    func testDecodesTransactionIdWhenPresent() throws {
+        let json = """
+        {
+          "networkToken": {"number": "ev:abc", "expiry": {"month": "12", "year": "30"}, "rawExpiry": "12/30", "tokenServiceProvider": "Apple"},
+          "card": {"brand": "visa"},
+          "cryptogram": "ev:cryptogram",
+          "eci": "5",
+          "paymentDataType": "3DSecure",
+          "deviceManufacturerIdentifier": "device-id",
+          "transactionId": "test-transaction-id-abc123"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ApplePayResponse.self, from: json)
+
+        XCTAssertEqual(decoded.transactionId, "test-transaction-id-abc123")
     }
 }
 


### PR DESCRIPTION
https://linear.app/evervault/issue/CARD-1027/apple-pay-expose-token-transactionid-in-api-response-web-ios

Tested manually, all works
<img width="987" height="433" alt="Screenshot 2026-07-21 at 13 14 46" src="https://github.com/user-attachments/assets/2ace00ef-6a5b-40c9-9b01-6e28653f8a50" />
