### PR TITLE
Bump ApplePay version for release

### DIFF
--- a/EvervaultPayment.podspec
+++ b/EvervaultPayment.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "EvervaultPayment"
-  spec.version      = "0.0.25"
+  spec.version      = "0.0.26"
   spec.summary      = "Evervault Pay SDK for iOS - Secure Apple Pay integration with Evervault encryption"
   spec.description  = <<-DESC
     The Evervault Pay SDK for iOS provides a secure way to integrate Apple Pay into your iOS applications.


### PR DESCRIPTION
Release for a few ApplePay feature parity changes grouped together
- 3-state availability for iOS SDK: https://github.com/evervault/evervault-pay/pull/40
- Distinct cancel vs success: https://github.com/evervault/evervault-pay/pull/41
- Expose transactionId to merchant: https://github.com/evervault/evervault-pay/pull/43

External docs updates are also ready:
- https://github.com/evervault/docs/pull/727
- https://github.com/evervault/docs/pull/745