### PR TITLE
Defer onDecline/onResult/onCancel reporting until after the Apple Pay sheet dismisses

### DIFF
--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -64,7 +64,7 @@ public class EvervaultPaymentView: UIView {
     /// dismissing, so it's safe for merchants to present their own UI in response.
     /// Reset to `nil` at the top of `didTapPay()`, before a new sheet is presented.
     /// If still `nil` when the sheet finishes, the buyer dismissed it without ever authorizing — a genuine cancel.
-    private var tapAuthorizationOutcome: AuthorizationOutcome?
+    private var tapAuthorizationOutcome: Result<Void, Error>?
 
     public weak var delegate: EvervaultPaymentViewDelegate? {
         didSet {
@@ -142,36 +142,28 @@ public class EvervaultPaymentView: UIView {
         return .available
     }
 
-    /// What happened when the merchant's authorization decision (or a genuine SDK failure) resolved for the
-    /// current attempt - recorded by `handleAuthorizationDisposition`/the `catch` block in `didAuthorizePayment`,
-    /// but not yet reported to the delegate.
-    enum AuthorizationOutcome {
-        case success
-        case declined(Error)
-        case sdkFailure(EvervaultError)
+    /// Marks a decline reported by the merchant via `shouldAuthorize`, so it can be recorded and later told
+    /// apart from a genuine SDK failure - always unwrapped back to `underlying` before it reaches a delegate,
+    /// so merchants only ever see their own error type, never this wrapper.
+    /// Not `public`, unlike `EvervaultError`: this is purely an SDK-internal bookkeeping detail, never part
+    /// of the delegate-facing API.
+    struct MerchantDeclinedError: Error, LocalizedError {
+        let underlying: Error
+
+        var errorDescription: String? {
+            "Merchant declined the payment: \(underlying.localizedDescription)"
+        }
     }
 
-    /// The verdict on how the current authorization attempt resolved, given how (or whether) `didAuthorizePayment` fired.
-    /// Carries whatever's needed to report it to the delegate - unlike `AuthorizationOutcome`, an associated
-    /// `Error`/`EvervaultError` isn't `Equatable`, so this type isn't either.
-    enum AuthorizationVerdict {
-        case success
-        case cancelled
-        case declined(Error)
-        case sdkFailure(EvervaultError)
-    }
-
-    /// Pure decision logic behind `paymentAuthorizationViewControllerDidFinish`, split out for testing without a live PassKit sheet.
-    nonisolated static func authorizationVerdict(for outcome: AuthorizationOutcome?) -> AuthorizationVerdict {
-        switch outcome {
+    /// Pure decision logic behind `handleAuthorizationDisposition`, split out for testing without a live PassKit sheet.
+    /// Maps the merchant's disposition onto what gets recorded in `tapAuthorizationOutcome` - a decline is wrapped
+    /// as `MerchantDeclinedError` so it can be told apart from a genuine SDK failure once it's time to report.
+    nonisolated static func resolveDisposition(for disposition: AuthorizationDisposition) -> Result<Void, Error> {
+        switch disposition {
         case .success:
-            return .success
-        case .declined(let reason):
-            return .declined(reason)
-        case .sdkFailure(let error):
-            return .sdkFailure(error)
-        case .none:
-            return .cancelled
+            return .success(())
+        case .failure(let reason):
+            return .failure(MerchantDeclinedError(underlying: reason))
         }
     }
 
@@ -180,13 +172,12 @@ public class EvervaultPaymentView: UIView {
     /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live PassKit sheet.
     @MainActor
     func handleAuthorizationDisposition(_ disposition: AuthorizationDisposition) -> PKPaymentAuthorizationResult {
+        self.tapAuthorizationOutcome = EvervaultPaymentView.resolveDisposition(for: disposition)
         switch disposition {
         case .success:
-            self.tapAuthorizationOutcome = .success
             // Tell Apple Pay the payment was successful
             return PKPaymentAuthorizationResult(status: .success, errors: nil)
         case .failure(let reason):
-            self.tapAuthorizationOutcome = .declined(reason)
             // The merchant rejected the payment: surface back to Apple Pay as a failure
             return PKPaymentAuthorizationResult(status: .failure, errors: [reason])
         }
@@ -197,8 +188,7 @@ public class EvervaultPaymentView: UIView {
     /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live network call.
     @MainActor
     func handleAuthorizationFailure(_ error: Error) -> PKPaymentAuthorizationResult {
-        let evError = EvervaultError.ApplePayAuthorizationError(underlying: error)
-        self.tapAuthorizationOutcome = .sdkFailure(evError)
+        self.tapAuthorizationOutcome = .failure(EvervaultError.ApplePayAuthorizationError(underlying: error))
         // On error, surface back to Apple Pay
         return PKPaymentAuthorizationResult(status: .failure, errors: [error])
     }
@@ -426,14 +416,18 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
     nonisolated public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         DispatchQueue.main.async { [weak self] in
             if let self = self {
-                switch EvervaultPaymentView.authorizationVerdict(for: self.tapAuthorizationOutcome) {
+                switch self.tapAuthorizationOutcome {
                 case .success:
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
-                case .declined(let reason):
-                    self.delegate?.evervaultPaymentView(self, didDeclinePayment: reason)
-                case .sdkFailure(let error):
-                    self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(error))
-                case .cancelled:
+                case .failure(let error as MerchantDeclinedError):
+                    // Unwrap back to the merchant's own error type - onDecline always hands back exactly what they threw.
+                    self.delegate?.evervaultPaymentView(self, didDeclinePayment: error.underlying)
+                case .failure(let evError as EvervaultError):
+                    self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(evError))
+                case .failure(let error):
+                    // handleAuthorizationFailure always stores an EvervaultError - this only matters if that invariant is ever broken.
+                    self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(.InternalError(underlying: error)))
+                case .none:
                     self.delegate?.evervaultPaymentViewDidCancel(self)
                 }
             }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -58,12 +58,13 @@ public class EvervaultPaymentView: UIView {
     public let buttonType: ButtonType
     public let buttonStyle: ButtonStyle
 
-    /// What happened when the merchant's authorization decision (or a genuine SDK failure) resolved for the
-    /// current attempt. Recorded during `didAuthorizePayment`, but not yet reported to the delegate —
-    /// reporting is deferred until `paymentAuthorizationViewControllerDidFinish`, once the sheet has begun
-    /// dismissing, so it's safe for merchants to present their own UI in response.
-    /// Reset to `nil` at the top of `didTapPay()`, before a new sheet is presented.
-    /// If still `nil` when the sheet finishes, the buyer dismissed it without ever authorizing — a genuine cancel.
+    /// The current attempt's outcome, recorded during `didAuthorizePayment` but reported only from
+    /// `paymentAuthorizationViewControllerDidFinish` - so merchants can safely present their own UI
+    /// once the sheet actually starts dismissing.
+    /// Reset to `nil` at the top of `didTapPay()`; still `nil` at finish means a genuine cancel.
+    ///
+    /// `Error`, not a closed enum, so the wrapped errors stay `Result.get()`-testable - see the fallback
+    /// switch case in `paymentAuthorizationViewControllerDidFinish` for the cost of that choice.
     private var tapAuthorizationOutcome: Result<Void, Error>?
 
     public weak var delegate: EvervaultPaymentViewDelegate? {
@@ -142,11 +143,9 @@ public class EvervaultPaymentView: UIView {
         return .available
     }
 
-    /// Marks a decline reported by the merchant via `shouldAuthorize`, so it can be recorded and later told
-    /// apart from a genuine SDK failure - always unwrapped back to `underlying` before it reaches a delegate,
-    /// so merchants only ever see their own error type, never this wrapper.
-    /// Not `public`, unlike `EvervaultError`: this is purely an SDK-internal bookkeeping detail, never part
-    /// of the delegate-facing API.
+
+    /// Wraps a merchant decline so it can be told apart from an SDK failure once it's time to report.
+    /// Always unwrapped back to `underlying` first, and never `public` like `EvervaultError` is.
     struct MerchantDeclinedError: Error, LocalizedError {
         let underlying: Error
 

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -58,13 +58,8 @@ public class EvervaultPaymentView: UIView {
     public let buttonType: ButtonType
     public let buttonStyle: ButtonStyle
 
-    /// The current attempt's outcome, recorded during `didAuthorizePayment` but reported only from
-    /// `paymentAuthorizationViewControllerDidFinish` - so merchants can safely present their own UI
-    /// once the sheet actually starts dismissing.
-    /// Reset to `nil` at the top of `didTapPay()`; still `nil` at finish means a genuine cancel.
-    ///
-    /// `Error`, not a closed enum, so the wrapped errors stay `Result.get()`-testable - see the fallback
-    /// switch case in `paymentAuthorizationViewControllerDidFinish` for the cost of that choice.
+    /// Outcome of the current attempt. `nil` here means the buyer cancelled.
+    /// Only reported from `paymentAuthorizationViewControllerDidFinish`.
     private var tapAuthorizationOutcome: Result<Void, Error>?
 
     public weak var delegate: EvervaultPaymentViewDelegate? {
@@ -143,9 +138,6 @@ public class EvervaultPaymentView: UIView {
         return .available
     }
 
-
-    /// Wraps a merchant decline so it can be told apart from an SDK failure once it's time to report.
-    /// Always unwrapped back to `underlying` first, and never `public` like `EvervaultError` is.
     struct MerchantDeclinedError: Error, LocalizedError {
         let underlying: Error
 
@@ -154,9 +146,6 @@ public class EvervaultPaymentView: UIView {
         }
     }
 
-    /// Pure decision logic behind `handleAuthorizationDisposition`, split out for testing without a live PassKit sheet.
-    /// Maps the merchant's disposition onto what gets recorded in `tapAuthorizationOutcome` - a decline is wrapped
-    /// as `MerchantDeclinedError` so it can be told apart from a genuine SDK failure once it's time to report.
     nonisolated static func resolveDisposition(for disposition: AuthorizationDisposition) -> Result<Void, Error> {
         switch disposition {
         case .success:
@@ -166,9 +155,8 @@ public class EvervaultPaymentView: UIView {
         }
     }
 
-    /// Records the merchant's authorization disposition and reports what to tell PassKit.
-    /// Does NOT notify the delegate - reporting is deferred until `paymentAuthorizationViewControllerDidFinish`,
-    /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live PassKit sheet.
+    /// Records the disposition without notifying the delegate.
+    /// Reporting is deferred to `paymentAuthorizationViewControllerDidFinish`.
     @MainActor
     func handleAuthorizationDisposition(_ disposition: AuthorizationDisposition) -> PKPaymentAuthorizationResult {
         self.tapAuthorizationOutcome = EvervaultPaymentView.resolveDisposition(for: disposition)
@@ -182,9 +170,8 @@ public class EvervaultPaymentView: UIView {
         }
     }
 
-    /// Records a genuine SDK-level failure (decode/network error from `didAuthorizePayment`) and reports what to tell PassKit.
-    /// Does NOT notify the delegate - reporting is deferred until `paymentAuthorizationViewControllerDidFinish`,
-    /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live network call.
+    /// Records an SDK-level failure without notifying the delegate.
+    /// Reporting is deferred to `paymentAuthorizationViewControllerDidFinish`.
     @MainActor
     func handleAuthorizationFailure(_ error: Error) -> PKPaymentAuthorizationResult {
         self.tapAuthorizationOutcome = .failure(EvervaultError.ApplePayAuthorizationError(underlying: error))
@@ -415,18 +402,18 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
     nonisolated public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         DispatchQueue.main.async { [weak self] in
             if let self = self {
+                // Clear now, rather than leaving stale outcome until the next didTapPay() reset.
+                defer { self.tapAuthorizationOutcome = nil }
                 switch self.tapAuthorizationOutcome {
                 case .success:
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
                 case .failure(let error as MerchantDeclinedError):
-                    // Unwrap back to the merchant's own error type - onDecline always hands back exactly what they threw.
+                    // Pass the merchant's original error, not our wrapper.
                     self.delegate?.evervaultPaymentView(self, didDeclinePayment: error.underlying)
                 case .failure(let evError as EvervaultError):
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(evError))
                 case .failure(let error):
-                    // Unreachable by construction: handleAuthorizationFailure always stores an EvervaultError,
-                    // and resolveDisposition always stores a MerchantDeclinedError. Fail loudly in debug/test
-                    // builds if a future change ever breaks that invariant, rather than silently misreporting.
+                    // Unreachable. Only MerchantDeclinedError/EvervaultError are ever stored.
                     assertionFailure("tapAuthorizationOutcome held an unrecognized error type: \(error)")
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(.InternalError(underlying: error)))
                 case .none:

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -171,20 +171,18 @@ public class EvervaultPaymentView: UIView {
         }
     }
 
-    /// Notifies the delegate of the merchant's authorization disposition and reports what to tell PassKit.
-    /// Unlike `authorizationVerdict`, this has side effects (calls the delegate, mutates `tapAuthorizationOutcome`) -
-    /// split out for testing with a spy delegate, without needing a live PassKit sheet.
+    /// Records the merchant's authorization disposition and reports what to tell PassKit.
+    /// Does NOT notify the delegate - reporting is deferred until `paymentAuthorizationViewControllerDidFinish`,
+    /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live PassKit sheet.
     @MainActor
     func handleAuthorizationDisposition(_ disposition: AuthorizationDisposition) -> PKPaymentAuthorizationResult {
         switch disposition {
         case .success:
-            self.tapAuthorizationOutcome = .success(())
+            self.tapAuthorizationOutcome = .success
             // Tell Apple Pay the payment was successful
             return PKPaymentAuthorizationResult(status: .success, errors: nil)
         case .failure(let reason):
-            // Notify the delegate on the main actor
-            self.delegate?.evervaultPaymentView(self, didDeclinePayment: reason)
-            self.tapAuthorizationOutcome = .failure(reason)
+            self.tapAuthorizationOutcome = .declined(reason)
             // The merchant rejected the payment: surface back to Apple Pay as a failure
             return PKPaymentAuthorizationResult(status: .failure, errors: [reason])
         }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -425,7 +425,10 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
                 case .failure(let evError as EvervaultError):
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(evError))
                 case .failure(let error):
-                    // handleAuthorizationFailure always stores an EvervaultError - this only matters if that invariant is ever broken.
+                    // Unreachable by construction: handleAuthorizationFailure always stores an EvervaultError,
+                    // and resolveDisposition always stores a MerchantDeclinedError. Fail loudly in debug/test
+                    // builds if a future change ever breaks that invariant, rather than silently misreporting.
+                    assertionFailure("tapAuthorizationOutcome held an unrecognized error type: \(error)")
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(.InternalError(underlying: error)))
                 case .none:
                     self.delegate?.evervaultPaymentViewDidCancel(self)

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -152,20 +152,24 @@ public class EvervaultPaymentView: UIView {
     }
 
     /// The verdict on how the current authorization attempt resolved, given how (or whether) `didAuthorizePayment` fired.
-    enum AuthorizationVerdict: Equatable {
+    /// Carries whatever's needed to report it to the delegate - unlike `AuthorizationOutcome`, an associated
+    /// `Error`/`EvervaultError` isn't `Equatable`, so this type isn't either.
+    enum AuthorizationVerdict {
         case success
         case cancelled
-        case failureAlreadyReported
+        case declined(Error)
+        case sdkFailure(EvervaultError)
     }
 
     /// Pure decision logic behind `paymentAuthorizationViewControllerDidFinish`, split out for testing without a live PassKit sheet.
-    nonisolated static func authorizationVerdict(for outcome: Result<Void, Error>?) -> AuthorizationVerdict {
+    nonisolated static func authorizationVerdict(for outcome: AuthorizationOutcome?) -> AuthorizationVerdict {
         switch outcome {
         case .success:
             return .success
-        case .failure:
-            // Already reported at the point of failure/decline.
-            return .failureAlreadyReported
+        case .declined(let reason):
+            return .declined(reason)
+        case .sdkFailure(let error):
+            return .sdkFailure(error)
         case .none:
             return .cancelled
         }
@@ -425,8 +429,10 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
                 switch EvervaultPaymentView.authorizationVerdict(for: self.tapAuthorizationOutcome) {
                 case .success:
                     self.delegate?.evervaultPaymentView(self, didFinishWithResult: .success(()))
-                case .failureAlreadyReported:
-                    break
+                case .declined(let reason):
+                    self.delegate?.evervaultPaymentView(self, didDeclinePayment: reason)
+                case .sdkFailure(let error):
+                    self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(error))
                 case .cancelled:
                     self.delegate?.evervaultPaymentViewDidCancel(self)
                 }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -188,6 +188,17 @@ public class EvervaultPaymentView: UIView {
         }
     }
 
+    /// Records a genuine SDK-level failure (decode/network error from `didAuthorizePayment`) and reports what to tell PassKit.
+    /// Does NOT notify the delegate - reporting is deferred until `paymentAuthorizationViewControllerDidFinish`,
+    /// once the sheet has begun dismissing. Split out for testing with a spy delegate, without needing a live network call.
+    @MainActor
+    func handleAuthorizationFailure(_ error: Error) -> PKPaymentAuthorizationResult {
+        let evError = EvervaultError.ApplePayAuthorizationError(underlying: error)
+        self.tapAuthorizationOutcome = .sdkFailure(evError)
+        // On error, surface back to Apple Pay
+        return PKPaymentAuthorizationResult(status: .failure, errors: [error])
+    }
+
     // MARK: Layout
     
     /// Set the intrinsic size of this component to the underlying button size
@@ -403,14 +414,7 @@ extension EvervaultPaymentView : PKPaymentAuthorizationViewControllerDelegate {
             let disposition = await self.delegate?.evervaultPaymentView(self, shouldAuthorize: enriched) ?? .success(())
             return await self.handleAuthorizationDisposition(disposition)
         } catch {
-            let evError = EvervaultError.ApplePayAuthorizationError(underlying: error)
-            await MainActor.run {
-                // Notify the delegate on the main actor
-                self.delegate?.evervaultPaymentView(self, didFinishWithResult: .failure(evError))
-                self.tapAuthorizationOutcome = .failure(evError)
-            }
-            // On error, surface back to Apple Pay
-            return PKPaymentAuthorizationResult(status: .failure, errors: [error])
+            return await self.handleAuthorizationFailure(error)
         }
     }
     

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -58,13 +58,13 @@ public class EvervaultPaymentView: UIView {
     public let buttonType: ButtonType
     public let buttonStyle: ButtonStyle
 
-    /// Whether a definite outcome (success, SDK failure, or merchant decline) has already been reported
-    /// to the delegate for the current authorization attempt - the specific error, if any, doesn't matter
-    /// here, only whether something was already reported.
-    /// Reset to `nil` at the top of `didTapPay()`, before a new sheet is presented;
-    /// set once `didAuthorizePayment` resolves to whichever outcome was reported.
+    /// What happened when the merchant's authorization decision (or a genuine SDK failure) resolved for the
+    /// current attempt. Recorded during `didAuthorizePayment`, but not yet reported to the delegate —
+    /// reporting is deferred until `paymentAuthorizationViewControllerDidFinish`, once the sheet has begun
+    /// dismissing, so it's safe for merchants to present their own UI in response.
+    /// Reset to `nil` at the top of `didTapPay()`, before a new sheet is presented.
     /// If still `nil` when the sheet finishes, the buyer dismissed it without ever authorizing — a genuine cancel.
-    private var tapAuthorizationOutcome: Result<Void, Error>?
+    private var tapAuthorizationOutcome: AuthorizationOutcome?
 
     public weak var delegate: EvervaultPaymentViewDelegate? {
         didSet {
@@ -140,6 +140,15 @@ public class EvervaultPaymentView: UIView {
             return .unavailable
         }
         return .available
+    }
+
+    /// What happened when the merchant's authorization decision (or a genuine SDK failure) resolved for the
+    /// current attempt - recorded by `handleAuthorizationDisposition`/the `catch` block in `didAuthorizePayment`,
+    /// but not yet reported to the delegate.
+    enum AuthorizationOutcome {
+        case success
+        case declined(Error)
+        case sdkFailure(EvervaultError)
     }
 
     /// The verdict on how the current authorization attempt resolved, given how (or whether) `didAuthorizePayment` fired.

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -299,6 +299,7 @@ final class ResolveDispositionTests: XCTestCase {
 private final class SpyDelegate: EvervaultPaymentViewDelegate {
     private(set) var didFinishWithResultCalls: [Result<Void, EvervaultError>] = []
     private(set) var didDeclinePaymentCalls: [Error] = []
+    private(set) var didCancelCallCount = 0
     /// Set by tests that need to wait for an async-dispatched delegate call (e.g. from
     /// `paymentAuthorizationViewControllerDidFinish`'s `DispatchQueue.main.async`) instead of racing it.
     var didReportExpectation: XCTestExpectation?
@@ -315,9 +316,15 @@ private final class SpyDelegate: EvervaultPaymentViewDelegate {
         didReportExpectation?.fulfill()
     }
 
+    func evervaultPaymentViewDidCancel(_ view: EvervaultPaymentView) {
+        didCancelCallCount += 1
+        didReportExpectation?.fulfill()
+    }
+
     func reset() {
         didFinishWithResultCalls = []
         didDeclinePaymentCalls = []
+        didCancelCallCount = 0
     }
 }
 
@@ -441,6 +448,39 @@ final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
 
         XCTAssertEqual(spy.didFinishWithResultCalls.count, 1)
         XCTAssertThrowsError(try XCTUnwrap(spy.didFinishWithResultCalls.first).get())
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
+    }
+
+    func testSuccessReportsAfterDidFinish() async {
+        let spy = SpyDelegate()
+        let view = makeViewForDispositionTests(delegate: spy)
+
+        _ = await view.handleAuthorizationDisposition(.success(()))
+        XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty, "must not fire before the sheet finishes")
+
+        let reported = expectation(description: "didFinishWithResult reported")
+        spy.didReportExpectation = reported
+        view.paymentAuthorizationViewControllerDidFinish(makeAuthorizationController())
+        await fulfillment(of: [reported], timeout: 1)
+
+        XCTAssertEqual(spy.didFinishWithResultCalls.count, 1)
+        XCTAssertNoThrow(try XCTUnwrap(spy.didFinishWithResultCalls.first).get())
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
+    }
+
+    func testCancelReportsWhenNoAuthorizationAttemptEverCompleted() async {
+        let spy = SpyDelegate()
+        let view = makeViewForDispositionTests(delegate: spy)
+
+        // Neither handleAuthorizationDisposition nor handleAuthorizationFailure ran - tapAuthorizationOutcome
+        // stays nil, exactly as if the buyer dismissed the sheet without ever authorizing.
+        let reported = expectation(description: "evervaultPaymentViewDidCancel reported")
+        spy.didReportExpectation = reported
+        view.paymentAuthorizationViewControllerDidFinish(makeAuthorizationController())
+        await fulfillment(of: [reported], timeout: 1)
+
+        XCTAssertEqual(spy.didCancelCallCount, 1)
+        XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
         XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
     }
 }

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -279,6 +279,7 @@ final class ApplePayAvailabilityTests: XCTestCase {
 }
 
 private struct TestDeclineReason: Error {}
+private struct TestNetworkError: Error {}
 
 final class ResolveDispositionTests: XCTestCase {
     func testSuccessDispositionMapsToSuccessOutcome() {
@@ -385,9 +386,8 @@ final class HandleAuthorizationFailureTests: XCTestCase {
     func testDoesNotNotifyDelegateAndReturnsFailureResult() async {
         let spy = SpyDelegate()
         let view = makeViewForDispositionTests(delegate: spy)
-        struct NetworkError: Error {}
 
-        let result = await view.handleAuthorizationFailure(NetworkError())
+        let result = await view.handleAuthorizationFailure(TestNetworkError())
 
         XCTAssertEqual(result.status, .failure)
         XCTAssertEqual(result.errors?.count, 1)
@@ -410,8 +410,8 @@ private func makeAuthorizationController() -> PKPaymentAuthorizationViewControll
     return PKPaymentAuthorizationViewController(paymentRequest: request)!
 }
 
-/// onDecline/onResult's failure case must fire only once `paymentAuthorizationViewControllerDidFinish` 
-/// runs (i.e. once PassKit has decided to close the sheet), 
+/// onDecline/onResult's failure case must fire only once `paymentAuthorizationViewControllerDidFinish`
+/// runs (i.e. once PassKit has decided to close the sheet),
 /// not at the point `handleAuthorizationDisposition`/`handleAuthorizationFailure` returns.
 @MainActor
 final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
@@ -436,9 +436,8 @@ final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
     func testSdkFailureFiresOnlyAfterDidFinishNotAfterHandleFailure() async {
         let spy = SpyDelegate()
         let view = makeViewForDispositionTests(delegate: spy)
-        struct NetworkError: Error {}
 
-        _ = await view.handleAuthorizationFailure(NetworkError())
+        _ = await view.handleAuthorizationFailure(TestNetworkError())
         XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty, "must not fire before the sheet finishes")
 
         let reported = expectation(description: "didFinishWithResult reported")

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -280,42 +280,39 @@ final class ApplePayAvailabilityTests: XCTestCase {
 
 private struct TestDeclineReason: Error {}
 
-final class AuthorizationVerdictTests: XCTestCase {
-    func testSuccessWhenAuthorizationSucceeded() {
-        let verdict = EvervaultPaymentView.authorizationVerdict(for: .success(()))
-        XCTAssertEqual(verdict, .success)
+final class ResolveDispositionTests: XCTestCase {
+    func testSuccessDispositionMapsToSuccessOutcome() {
+        let outcome = EvervaultPaymentView.resolveDisposition(for: .success(()))
+        XCTAssertNoThrow(try outcome.get())
     }
 
-    func testFailureAlreadyReportedWhenAuthorizationFailed() {
-        let verdict = EvervaultPaymentView.authorizationVerdict(for: .failure(EvervaultError.ApplePayUnavailableError))
-        XCTAssertEqual(verdict, .failureAlreadyReported)
-    }
+    func testFailureDispositionMapsToMerchantDeclinedError() {
+        let reason = TestDeclineReason()
+        let outcome = EvervaultPaymentView.resolveDisposition(for: .failure(reason))
 
-    func testFailureAlreadyReportedWhenDeclined() {
-        // Declines carry the merchant's own error type, not an EvervaultError - the verdict doesn't
-        // care about the concrete type, only that something was already reported.
-        let verdict = EvervaultPaymentView.authorizationVerdict(for: .failure(TestDeclineReason()))
-        XCTAssertEqual(verdict, .failureAlreadyReported)
-    }
-
-    func testCancelledWhenNoAuthorizationAttemptCompleted() {
-        let verdict = EvervaultPaymentView.authorizationVerdict(for: nil)
-        XCTAssertEqual(verdict, .cancelled)
+        XCTAssertThrowsError(try outcome.get()) { error in
+            XCTAssertEqual(error.localizedDescription, "Merchant declined the payment: \(reason.localizedDescription)")
+        }
     }
 }
 
 private final class SpyDelegate: EvervaultPaymentViewDelegate {
     private(set) var didFinishWithResultCalls: [Result<Void, EvervaultError>] = []
     private(set) var didDeclinePaymentCalls: [Error] = []
+    /// Set by tests that need to wait for an async-dispatched delegate call (e.g. from
+    /// `paymentAuthorizationViewControllerDidFinish`'s `DispatchQueue.main.async`) instead of racing it.
+    var didReportExpectation: XCTestExpectation?
 
     func evervaultPaymentView(_ view: EvervaultPaymentView, didAuthorizePayment result: ApplePayResponse?) {}
 
     func evervaultPaymentView(_ view: EvervaultPaymentView, didFinishWithResult result: Result<Void, EvervaultError>) {
         didFinishWithResultCalls.append(result)
+        didReportExpectation?.fulfill()
     }
 
     func evervaultPaymentView(_ view: EvervaultPaymentView, didDeclinePayment reason: Error) {
         didDeclinePaymentCalls.append(reason)
+        didReportExpectation?.fulfill()
     }
 
     func reset() {
@@ -360,7 +357,7 @@ final class HandleAuthorizationDispositionTests: XCTestCase {
         XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
     }
 
-    func testFailureNotifiesDidDeclinePaymentOnlyNotDidFinishWithResult() async {
+    func testFailureDoesNotNotifyDelegateAndReturnsFailureResult() async {
         let spy = SpyDelegate()
         let view = makeViewForDispositionTests(delegate: spy)
         let reason = TestDeclineReason()
@@ -368,15 +365,82 @@ final class HandleAuthorizationDispositionTests: XCTestCase {
         let result = await view.handleAuthorizationDisposition(.failure(reason))
 
         XCTAssertEqual(result.status, .failure)
-        // result.errors?.first isn't checked for its exact type here. 
-        // PKPaymentAuthorizationResult is a PassKit type, and passing an error through it 
-        // changes what type comes back out - so a type check here would fail 
-        // even though we did pass a TestDeclineReason in.
-        // The didDeclinePayment check below is the trustworthy one: it receives our error
-        // directly, without going through PassKit at all.
         XCTAssertEqual(result.errors?.count, 1)
+        // Reporting is deferred to paymentAuthorizationViewControllerDidFinish, once the sheet has
+        // begun dismissing - see PaymentAuthorizationViewControllerDidFinishTests below.
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
+        XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
+    }
+}
+
+@MainActor
+final class HandleAuthorizationFailureTests: XCTestCase {
+    func testDoesNotNotifyDelegateAndReturnsFailureResult() async {
+        let spy = SpyDelegate()
+        let view = makeViewForDispositionTests(delegate: spy)
+        struct NetworkError: Error {}
+
+        let result = await view.handleAuthorizationFailure(NetworkError())
+
+        XCTAssertEqual(result.status, .failure)
+        XCTAssertEqual(result.errors?.count, 1)
+        // Reporting is deferred to paymentAuthorizationViewControllerDidFinish, once the sheet has
+        // begun dismissing - see PaymentAuthorizationViewControllerDidFinishTests below.
+        XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
+    }
+}
+
+@MainActor
+private func makeAuthorizationController() -> PKPaymentAuthorizationViewController {
+    let request = PKPaymentRequest()
+    request.merchantIdentifier = "merchant.test"
+    request.supportedNetworks = [.visa]
+    request.countryCode = "IE"
+    request.currencyCode = "EUR"
+    request.paymentSummaryItems = [PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(string: "10.00"))]
+    request.merchantCapabilities = .threeDSecure
+    return PKPaymentAuthorizationViewController(paymentRequest: request)!
+}
+
+/// onDecline/onResult's failure case must fire only once `paymentAuthorizationViewControllerDidFinish` 
+/// runs (i.e. once PassKit has decided to close the sheet), 
+/// not at the point `handleAuthorizationDisposition`/`handleAuthorizationFailure` returns.
+@MainActor
+final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
+    func testDeclineFiresOnlyAfterDidFinishNotAfterHandleDisposition() async {
+        let spy = SpyDelegate()
+        let view = makeViewForDispositionTests(delegate: spy)
+        let reason = TestDeclineReason()
+
+        _ = await view.handleAuthorizationDisposition(.failure(reason))
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty, "must not fire before the sheet finishes")
+
+        let reported = expectation(description: "didDeclinePayment reported")
+        spy.didReportExpectation = reported
+        view.paymentAuthorizationViewControllerDidFinish(makeAuthorizationController())
+        await fulfillment(of: [reported], timeout: 1)
+
         XCTAssertEqual(spy.didDeclinePaymentCalls.count, 1)
         XCTAssertTrue(spy.didDeclinePaymentCalls.first is TestDeclineReason)
         XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
+    }
+
+    func testSdkFailureFiresOnlyAfterDidFinishNotAfterHandleFailure() async {
+        let spy = SpyDelegate()
+        let view = makeViewForDispositionTests(delegate: spy)
+        struct NetworkError: Error {}
+
+        _ = await view.handleAuthorizationFailure(NetworkError())
+        XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty, "must not fire before the sheet finishes")
+
+        let reported = expectation(description: "didFinishWithResult reported")
+        spy.didReportExpectation = reported
+        view.paymentAuthorizationViewControllerDidFinish(makeAuthorizationController())
+        await fulfillment(of: [reported], timeout: 1)
+
+        XCTAssertEqual(spy.didFinishWithResultCalls.count, 1)
+        XCTAssertThrowsError(try XCTUnwrap(spy.didFinishWithResultCalls.first).get())
+        XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
     }
 }

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -301,8 +301,7 @@ private final class SpyDelegate: EvervaultPaymentViewDelegate {
     private(set) var didFinishWithResultCalls: [Result<Void, EvervaultError>] = []
     private(set) var didDeclinePaymentCalls: [Error] = []
     private(set) var didCancelCallCount = 0
-    /// Set by tests that need to wait for an async-dispatched delegate call (e.g. from
-    /// `paymentAuthorizationViewControllerDidFinish`'s `DispatchQueue.main.async`) instead of racing it.
+    /// Lets a test await an async-dispatched delegate call instead of racing it.
     var didReportExpectation: XCTestExpectation?
 
     func evervaultPaymentView(_ view: EvervaultPaymentView, didAuthorizePayment result: ApplePayResponse?) {}
@@ -374,8 +373,7 @@ final class HandleAuthorizationDispositionTests: XCTestCase {
 
         XCTAssertEqual(result.status, .failure)
         XCTAssertEqual(result.errors?.count, 1)
-        // Reporting is deferred to paymentAuthorizationViewControllerDidFinish, once the sheet has
-        // begun dismissing - see PaymentAuthorizationViewControllerDidFinishTests below.
+        // Deferred to paymentAuthorizationViewControllerDidFinish.
         XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
         XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
     }
@@ -391,8 +389,7 @@ final class HandleAuthorizationFailureTests: XCTestCase {
 
         XCTAssertEqual(result.status, .failure)
         XCTAssertEqual(result.errors?.count, 1)
-        // Reporting is deferred to paymentAuthorizationViewControllerDidFinish, once the sheet has
-        // begun dismissing - see PaymentAuthorizationViewControllerDidFinishTests below.
+        // Deferred to paymentAuthorizationViewControllerDidFinish.
         XCTAssertTrue(spy.didFinishWithResultCalls.isEmpty)
         XCTAssertTrue(spy.didDeclinePaymentCalls.isEmpty)
     }
@@ -410,9 +407,8 @@ private func makeAuthorizationController() -> PKPaymentAuthorizationViewControll
     return PKPaymentAuthorizationViewController(paymentRequest: request)!
 }
 
-/// onDecline/onResult's failure case must fire only once `paymentAuthorizationViewControllerDidFinish`
-/// runs (i.e. once PassKit has decided to close the sheet),
-/// not at the point `handleAuthorizationDisposition`/`handleAuthorizationFailure` returns.
+/// Proves reporting happens only from `paymentAuthorizationViewControllerDidFinish`,
+/// not from `handleAuthorizationDisposition`/`handleAuthorizationFailure`.
 @MainActor
 final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
     func testDeclineFiresOnlyAfterDidFinishNotAfterHandleDisposition() async {
@@ -471,8 +467,7 @@ final class PaymentAuthorizationViewControllerDidFinishTests: XCTestCase {
         let spy = SpyDelegate()
         let view = makeViewForDispositionTests(delegate: spy)
 
-        // Neither handleAuthorizationDisposition nor handleAuthorizationFailure ran - tapAuthorizationOutcome
-        // stays nil, exactly as if the buyer dismissed the sheet without ever authorizing.
+        // No handler ran, so tapAuthorizationOutcome stays nil.
         let reported = expectation(description: "evervaultPaymentViewDidCancel reported")
         spy.didReportExpectation = reported
         view.paymentAuthorizationViewControllerDidFinish(makeAuthorizationController())


### PR DESCRIPTION
**Today:** onDecline and onResult's failure case fire the moment a merchant declines (shouldAuthorize returning .failure) or a genuine SDK-level error occurs — while Apple's Pay sheet is still fully on screen. Success and cancel already deferred correctly to paymentAuthorizationViewControllerDidFinish; decline and SDK failure didn't, so merchants presenting their own UI in response risk fighting with the still-open native sheet.

**Change:** decline and SDK-failure outcomes are now recorded at the point they occur (handleAuthorizationDisposition/handleAuthorizationFailure) but only reported to the delegate from paymentAuthorizationViewControllerDidFinish, once PassKit has decided to close the sheet — matching the existing success/cancel timing. A new MerchantDeclinedError (SDK-internal, not part of the public EvervaultError API) lets the deferred reporting tell a decline apart from a genuine SDK failure so it routes to the right delegate method.

**Tested:** unit tests cover all four terminal states (success, decline, SDK failure, cancel) reporting only from paymentAuthorizationViewControllerDidFinish, not at the point of failure/decline. Also checked manually for all possible results.

**Linear:** https://linear.app/evervault/issue/CARD-1088/ios-defer-ondeclineonresult-failure-reporting-until-after-the-apple

