### PR TITLE
Add billingContact & shippingContact prefill to ApplePay 

### DIFF
--- a/ios/Demo/Demo/ContentView.swift
+++ b/ios/Demo/Demo/ContentView.swift
@@ -9,6 +9,39 @@ import SwiftUI
 import EvervaultPayment
 import PassKit
 
+// Sample prefill contacts, exercising the new `ApplePayPaymentContact` billing/shipping prefill.
+// PassKit only surfaces the postal-address portion if `.postalAddress` is also in the
+// matching `required...ContactFields` set below - see `ApplePayPaymentContact`'s doc comment.
+fileprivate func makeSampleBillingContact() -> ApplePayPaymentContact {
+    ApplePayPaymentContact(
+        givenName: "Harry",
+        familyName: "Potter",
+        emailAddress: "harry.potter@hogwarts.edu",
+        phoneNumber: "+442079460958",
+        addressLines: ["4 Privet Drive"],
+        locality: "Little Whinging",
+        postalCode: "GU21 5RH",
+        administrativeArea: "Surrey",
+        country: "United Kingdom",
+        countryCode: "GB"
+    )
+}
+
+fileprivate func makeSampleShippingContact() -> ApplePayPaymentContact {
+    ApplePayPaymentContact(
+        givenName: "Hermione",
+        familyName: "Granger",
+        emailAddress: "hermione.granger@hogwarts.edu",
+        phoneNumber: "+442079460321",
+        addressLines: ["Hogwarts School of Witchcraft and Wizardry"],
+        locality: "Hogsmeade",
+        postalCode: "HG1 1SW",
+        administrativeArea: "Scottish Highlands",
+        country: "United Kingdom",
+        countryCode: "GB"
+    )
+}
+
 fileprivate func buildTransaction(type: TransactionType) -> EvervaultPayment.Transaction {
     switch type {
     case .disbursement:
@@ -37,7 +70,13 @@ fileprivate func buildTransaction(type: TransactionType) -> EvervaultPayment.Tra
                  SummaryItem(label: "Socks", amount: Amount("5.00")),
                  SummaryItem(label: "Total", amount: Amount("35.00"))
              ],
-             supportsCouponCode: true
+             shippingType: .shipping,
+             shippingMethods: [],
+             requiredShippingContactFields: [.postalAddress, .name, .emailAddress, .phoneNumber],
+             requestPayerDetails: [.postalAddress, .name, .emailAddress, .phoneNumber],
+             supportsCouponCode: true,
+             billingContact: makeSampleBillingContact(),
+             shippingContact: makeSampleShippingContact()
          ))
     case .recurring:
         let express = ShippingMethod(
@@ -46,14 +85,14 @@ fileprivate func buildTransaction(type: TransactionType) -> EvervaultPayment.Tra
         )
         express.identifier = "express_1day"
         express.detail = "Arrives in 1–2 business days."
-        
+
         let standard = ShippingMethod(
             label: "Standard Shipping",
             amount: NSDecimalNumber(string: "2.99")
         )
         standard.identifier = "standard_3day"
         standard.detail = "Arrives in 3-5 business days."
-        
+
         let recurringBilling = PKRecurringPaymentSummaryItem(
             label: "Pro Subscription",
             amount: 5.00
@@ -63,17 +102,23 @@ fileprivate func buildTransaction(type: TransactionType) -> EvervaultPayment.Tra
         var dateComponent = DateComponents()
         dateComponent.day = 7
         recurringBilling.startDate = Calendar.current.date(byAdding: dateComponent, to: Date())
-        
+
         let trialBilling = PKRecurringPaymentSummaryItem(label: "Trial", amount: 0)
         trialBilling.startDate = nil // Now
-        
+
         var recurringBillingRequest = try! RecurringPaymentTransaction(
             country: "IE",
             currency: "EUR",
             paymentSummaryItems: [],
             paymentDescription: "Recurring payment example.",
             regularBilling: recurringBilling,
-            managementURL: URL(string: "https://www.merchant.com/manage-subscriptions")!
+            managementURL: URL(string: "https://www.merchant.com/manage-subscriptions")!,
+            requestPayerDetails: [.postalAddress, .name, .emailAddress, .phoneNumber],
+            billingContact: makeSampleBillingContact(),
+            shippingType: .shipping,
+            shippingMethods: [express, standard],
+            requiredShippingContactFields: [.postalAddress, .name, .emailAddress, .phoneNumber],
+            shippingContact: makeSampleShippingContact()
         )
         recurringBillingRequest.billingAgreement = "https://www.merchant.com/billing-agreement"
         recurringBillingRequest.trialBilling = trialBilling

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/EvervaultPayment.swift
@@ -288,6 +288,13 @@ public class EvervaultPaymentView: UIView {
         paymentRequest.supportsCouponCode = transaction.supportsCouponCode
         paymentRequest.couponCode = transaction.couponCode
 
+        if let billingContact = transaction.billingContact {
+            paymentRequest.billingContact = PKContact(billingContact)
+        }
+        if let shippingContact = transaction.shippingContact {
+            paymentRequest.shippingContact = PKContact(shippingContact)
+        }
+
         return paymentRequest
     }
 
@@ -353,6 +360,17 @@ public class EvervaultPaymentView: UIView {
         paymentRequest.requiredBillingContactFields = transaction.requestPayerDetails
         paymentRequest.supportsCouponCode = transaction.supportsCouponCode
         paymentRequest.couponCode = transaction.couponCode
+
+        paymentRequest.shippingType = transaction.shippingType
+        paymentRequest.shippingMethods = transaction.shippingMethods
+        paymentRequest.requiredShippingContactFields = transaction.requiredShippingContactFields
+
+        if let billingContact = transaction.billingContact {
+            paymentRequest.billingContact = PKContact(billingContact)
+        }
+        if let shippingContact = transaction.shippingContact {
+            paymentRequest.shippingContact = PKContact(shippingContact)
+        }
 
         return paymentRequest
     }

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -289,8 +289,10 @@ public struct OneOffPaymentTransaction {
     public var requestPayerDetails: Set<ContactField>
     public var supportsCouponCode: Bool
     public var couponCode: String?
+    public var billingContact: ApplePayPaymentContact?
+    public var shippingContact: ApplePayPaymentContact?
 
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil) throws {
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil, shippingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
@@ -300,6 +302,8 @@ public struct OneOffPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.billingContact = billingContact
+        self.shippingContact = shippingContact
 
         guard paymentSummaryItems.count > 0 else {
             throw EvervaultError.InvalidTransactionError
@@ -307,7 +311,7 @@ public struct OneOffPaymentTransaction {
     }
 
     @available(iOS 16, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem], shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil, shippingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
@@ -317,6 +321,8 @@ public struct OneOffPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.billingContact = billingContact
+        self.shippingContact = shippingContact
 
         guard paymentSummaryItems.count > 0 else {
             throw EvervaultError.InvalidTransactionError
@@ -388,8 +394,9 @@ public struct RecurringPaymentTransaction {
     public var requestPayerDetails: Set<ContactField>
     public var supportsCouponCode: Bool
     public var couponCode: String?
+    public var billingContact: ApplePayPaymentContact?
 
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil) throws {
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
@@ -399,10 +406,11 @@ public struct RecurringPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.billingContact = billingContact
     }
 
     @available(iOS 16.0, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
@@ -412,6 +420,7 @@ public struct RecurringPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.billingContact = billingContact
 
         guard currency.isISOCurrency else {
             throw EvervaultError.InvalidCurrencyError

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -86,6 +86,113 @@ public struct ApplePayContact: Codable, Sendable, Equatable {
     }
 }
 
+/// Prefill input for `PKPaymentRequest.billingContact` / `.shippingContact`.
+///
+/// Address prefill only appears if `.postalAddress` is in `requiredBillingContactFields` / `requiredShippingContactFields`.
+public struct ApplePayPaymentContact: Sendable, Equatable {
+    public var givenName: String?
+    public var familyName: String?
+    public var phoneticGivenName: String?
+    public var phoneticFamilyName: String?
+    public var emailAddress: String?
+    public var phoneNumber: String?
+    public var addressLines: [String]?
+    public var subLocality: String?
+    public var locality: String?
+    public var postalCode: String?
+    public var subAdministrativeArea: String?
+    public var administrativeArea: String?
+    public var country: String?
+    public var countryCode: String?
+
+    public init(
+        givenName: String? = nil,
+        familyName: String? = nil,
+        phoneticGivenName: String? = nil,
+        phoneticFamilyName: String? = nil,
+        emailAddress: String? = nil,
+        phoneNumber: String? = nil,
+        addressLines: [String]? = nil,
+        subLocality: String? = nil,
+        locality: String? = nil,
+        postalCode: String? = nil,
+        subAdministrativeArea: String? = nil,
+        administrativeArea: String? = nil,
+        country: String? = nil,
+        countryCode: String? = nil
+    ) {
+        self.givenName = givenName
+        self.familyName = familyName
+        self.phoneticGivenName = phoneticGivenName
+        self.phoneticFamilyName = phoneticFamilyName
+        self.emailAddress = emailAddress
+        self.phoneNumber = phoneNumber
+        self.addressLines = addressLines
+        self.subLocality = subLocality
+        self.locality = locality
+        self.postalCode = postalCode
+        self.subAdministrativeArea = subAdministrativeArea
+        self.administrativeArea = administrativeArea
+        self.country = country
+        self.countryCode = countryCode
+    }
+}
+
+/// True if at least one of the given values is non-nil.
+private func hasAnyValue(_ values: String?...) -> Bool {
+    values.contains { $0 != nil }
+}
+
+private extension ApplePayPaymentContact {
+    /// Returns `nil` unless at least one name field is set, so PassKit never receives an empty name.
+    var nameComponents: PersonNameComponents? {
+        guard hasAnyValue(givenName, familyName, phoneticGivenName, phoneticFamilyName) else { return nil }
+
+        var components = PersonNameComponents()
+        components.givenName = givenName
+        components.familyName = familyName
+
+        if hasAnyValue(phoneticGivenName, phoneticFamilyName) {
+            var phoneticComponents = PersonNameComponents()
+            phoneticComponents.givenName = phoneticGivenName
+            phoneticComponents.familyName = phoneticFamilyName
+            components.phoneticRepresentation = phoneticComponents
+        }
+
+        return components
+    }
+
+    /// Returns `nil` unless at least one address field is set, so PassKit never receives an empty address.
+    var mutablePostalAddress: CNMutablePostalAddress? {
+        let hasAddressLines = addressLines?.isEmpty == false
+        guard hasAddressLines || hasAnyValue(subLocality, locality, postalCode, subAdministrativeArea, administrativeArea, country, countryCode) else {
+            return nil
+        }
+
+        let address = CNMutablePostalAddress()
+        address.street = (addressLines ?? []).joined(separator: "\n")
+        address.subLocality = subLocality ?? ""
+        address.city = locality ?? ""
+        address.subAdministrativeArea = subAdministrativeArea ?? ""
+        address.state = administrativeArea ?? ""
+        address.postalCode = postalCode ?? ""
+        address.country = country ?? ""
+        address.isoCountryCode = countryCode ?? ""
+        return address
+    }
+}
+
+extension PKContact {
+    /// For prefilling the Apple Pay sheet from a plain `ApplePayPaymentContact`.
+    convenience init(_ contact: ApplePayPaymentContact) {
+        self.init()
+        self.name = contact.nameComponents
+        self.emailAddress = contact.emailAddress
+        self.phoneNumber = contact.phoneNumber.map(CNPhoneNumber.init(stringValue:))
+        self.postalAddress = contact.mutablePostalAddress
+    }
+}
+
 public enum ApplePayTransactionType: String, Codable, Sendable, Equatable {
     case oneOff
     case recurring

--- a/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
+++ b/ios/EvervaultPayment/Sources/EvervaultPayment/Models.swift
@@ -394,9 +394,13 @@ public struct RecurringPaymentTransaction {
     public var requestPayerDetails: Set<ContactField>
     public var supportsCouponCode: Bool
     public var couponCode: String?
+    public var shippingType: PKShippingType
+    public var shippingMethods: [PKShippingMethod]
+    public var requiredShippingContactFields: Set<ContactField>
     public var billingContact: ApplePayPaymentContact?
+    public var shippingContact: ApplePayPaymentContact?
 
-    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil) throws {
+    public init(country: String, currency: String, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil, shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], shippingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country
         self.currency = currency
         self.paymentSummaryItems = paymentSummaryItems
@@ -406,11 +410,15 @@ public struct RecurringPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.shippingType = shippingType
+        self.shippingMethods = shippingMethods
+        self.requiredShippingContactFields = requiredShippingContactFields
         self.billingContact = billingContact
+        self.shippingContact = shippingContact
     }
 
     @available(iOS 16.0, *)
-    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil) throws {
+    public init(country: Locale.Region, currency: Locale.Currency, paymentSummaryItems: [SummaryItem] = [], paymentDescription: String, regularBilling: PKRecurringPaymentSummaryItem, managementURL: URL, requestPayerDetails: Set<ContactField> = [], supportsCouponCode: Bool = false, couponCode: String? = nil, billingContact: ApplePayPaymentContact? = nil, shippingType: PKShippingType = .shipping, shippingMethods: [PKShippingMethod] = [], requiredShippingContactFields: Set<ContactField> = [], shippingContact: ApplePayPaymentContact? = nil) throws {
         self.country = country.identifier
         self.currency = currency.identifier
         self.paymentSummaryItems = paymentSummaryItems
@@ -420,7 +428,11 @@ public struct RecurringPaymentTransaction {
         self.requestPayerDetails = requestPayerDetails
         self.supportsCouponCode = supportsCouponCode
         self.couponCode = couponCode
+        self.shippingType = shippingType
+        self.shippingMethods = shippingMethods
+        self.requiredShippingContactFields = requiredShippingContactFields
         self.billingContact = billingContact
+        self.shippingContact = shippingContact
 
         guard currency.isISOCurrency else {
             throw EvervaultError.InvalidCurrencyError

--- a/ios/EvervaultPaymentTests/ModelsTests.swift
+++ b/ios/EvervaultPaymentTests/ModelsTests.swift
@@ -116,6 +116,84 @@ final class ApplePayContactTests: XCTestCase {
     }
 }
 
+final class ApplePayPaymentContactToPKContactTests: XCTestCase {
+    func testMapsAllFieldsIncludingAddress() {
+        let contact = ApplePayPaymentContact(
+            givenName: "Taro",
+            familyName: "Yamada",
+            phoneticGivenName: "たろう",
+            phoneticFamilyName: "やまだ",
+            emailAddress: "taro@example.com",
+            phoneNumber: "+15555550100",
+            addressLines: ["1 Main St", "Apt 2"],
+            subLocality: "Ranelagh",
+            locality: "Dublin",
+            postalCode: "D01",
+            subAdministrativeArea: "Dublin County",
+            administrativeArea: "Leinster",
+            country: "Ireland",
+            countryCode: "IE"
+        )
+
+        let result = PKContact(contact)
+
+        XCTAssertEqual(result.name?.givenName, "Taro")
+        XCTAssertEqual(result.name?.familyName, "Yamada")
+        XCTAssertEqual(result.name?.phoneticRepresentation?.givenName, "たろう")
+        XCTAssertEqual(result.name?.phoneticRepresentation?.familyName, "やまだ")
+        XCTAssertEqual(result.emailAddress, "taro@example.com")
+        XCTAssertEqual(result.phoneNumber?.stringValue, "+15555550100")
+        XCTAssertEqual(result.postalAddress?.street, "1 Main St\nApt 2")
+        XCTAssertEqual(result.postalAddress?.subLocality, "Ranelagh")
+        XCTAssertEqual(result.postalAddress?.city, "Dublin")
+        XCTAssertEqual(result.postalAddress?.postalCode, "D01")
+        XCTAssertEqual(result.postalAddress?.subAdministrativeArea, "Dublin County")
+        XCTAssertEqual(result.postalAddress?.state, "Leinster")
+        XCTAssertEqual(result.postalAddress?.country, "Ireland")
+        XCTAssertEqual(result.postalAddress?.isoCountryCode, "IE")
+    }
+
+    func testNoNameFieldsProducesNilName() {
+        let contact = ApplePayPaymentContact(emailAddress: "only-email@example.com")
+
+        let result = PKContact(contact)
+
+        XCTAssertNil(result.name)
+        XCTAssertEqual(result.emailAddress, "only-email@example.com")
+    }
+
+    func testNameWithoutPhoneticFieldsOmitsPhoneticRepresentation() {
+        let contact = ApplePayPaymentContact(givenName: "Ana", familyName: "M")
+
+        let result = PKContact(contact)
+
+        XCTAssertEqual(result.name?.givenName, "Ana")
+        XCTAssertEqual(result.name?.familyName, "M")
+        XCTAssertNil(result.name?.phoneticRepresentation)
+    }
+
+    func testNoAddressFieldsProducesNilPostalAddress() {
+        let contact = ApplePayPaymentContact(emailAddress: "only-email@example.com")
+
+        let result = PKContact(contact)
+
+        XCTAssertNil(result.postalAddress)
+    }
+
+    func testAddressLinesOnlyStillBuildsAddress() {
+        let contact = ApplePayPaymentContact(addressLines: ["1 Main St"])
+
+        let result = PKContact(contact)
+
+        XCTAssertEqual(result.postalAddress?.street, "1 Main St")
+        XCTAssertEqual(result.postalAddress?.city, "")
+        XCTAssertEqual(result.postalAddress?.state, "")
+        XCTAssertEqual(result.postalAddress?.postalCode, "")
+        XCTAssertEqual(result.postalAddress?.country, "")
+        XCTAssertEqual(result.postalAddress?.isoCountryCode, "")
+    }
+}
+
 final class ApplePayTransactionTypeTests: XCTestCase {
     func testMapsOneOffPayment() throws {
         let transaction = Transaction.oneOffPayment(try OneOffPaymentTransaction(
@@ -150,6 +228,79 @@ final class ApplePayTransactionTypeTests: XCTestCase {
         ))
 
         XCTAssertEqual(ApplePayTransactionType(transaction), .disbursement)
+    }
+}
+
+final class TransactionPrefillFieldsTests: XCTestCase {
+    private func makeBillingContact() -> ApplePayPaymentContact {
+        ApplePayPaymentContact(givenName: "John", familyName: "Doe")
+    }
+
+    private func makeShippingContact() -> ApplePayPaymentContact {
+        ApplePayPaymentContact(givenName: "Jane", familyName: "Doe")
+    }
+
+    func testOneOffDefaultsBillingAndShippingContactToNil() throws {
+        let transaction = try OneOffPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentSummaryItems: [SummaryItem(label: "Total", amount: Amount("10.00"))]
+        )
+
+        XCTAssertNil(transaction.billingContact)
+        XCTAssertNil(transaction.shippingContact)
+    }
+
+    func testOneOffStoresProvidedBillingAndShippingContact() throws {
+        let transaction = try OneOffPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentSummaryItems: [SummaryItem(label: "Total", amount: Amount("10.00"))],
+            billingContact: makeBillingContact(),
+            shippingContact: makeShippingContact()
+        )
+
+        XCTAssertEqual(transaction.billingContact?.givenName, "John")
+        XCTAssertEqual(transaction.shippingContact?.givenName, "Jane")
+    }
+
+    func testRecurringDefaultsBillingContactAndShippingFieldsToNilOrEmpty() throws {
+        let transaction = try RecurringPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentDescription: "Subscription",
+            regularBilling: PKRecurringPaymentSummaryItem(label: "Monthly", amount: NSDecimalNumber(string: "10.00")),
+            managementURL: URL(string: "https://example.com/manage")!
+        )
+
+        XCTAssertNil(transaction.billingContact)
+        XCTAssertNil(transaction.shippingContact)
+        XCTAssertEqual(transaction.shippingType, .shipping)
+        XCTAssertTrue(transaction.shippingMethods.isEmpty)
+        XCTAssertTrue(transaction.requiredShippingContactFields.isEmpty)
+    }
+
+    func testRecurringStoresProvidedBillingShippingAndShippingFields() throws {
+        let shippingMethod = PKShippingMethod(label: "Standard", amount: NSDecimalNumber(string: "5.00"))
+        let transaction = try RecurringPaymentTransaction(
+            country: "IE",
+            currency: "EUR",
+            paymentDescription: "Subscription",
+            regularBilling: PKRecurringPaymentSummaryItem(label: "Monthly", amount: NSDecimalNumber(string: "10.00")),
+            managementURL: URL(string: "https://example.com/manage")!,
+            billingContact: makeBillingContact(),
+            shippingType: .delivery,
+            shippingMethods: [shippingMethod],
+            requiredShippingContactFields: [.postalAddress],
+            shippingContact: makeShippingContact()
+        )
+
+        XCTAssertEqual(transaction.billingContact?.givenName, "John")
+        XCTAssertEqual(transaction.shippingContact?.givenName, "Jane")
+        XCTAssertEqual(transaction.shippingType, .delivery)
+        XCTAssertEqual(transaction.shippingMethods.count, 1)
+        XCTAssertTrue(transaction.shippingMethods.first === shippingMethod)
+        XCTAssertEqual(transaction.requiredShippingContactFields, [.postalAddress])
     }
 }
 


### PR DESCRIPTION
Also adds shipping support to recurring payments to mirror ApplePay web.
External docs changes: https://github.com/evervault/docs/pull/806

https://linear.app/evervault/issue/CARD-1052/b-apple-pay-ios-billingcontact-shippingcontact-prefill
